### PR TITLE
Build a basic version of the banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-.sass-cache/
-bower_components/
+.sass-cache
+bower_components
+coverage
 demos/local
-node_modules/
+node_modules
 npm-debug.log

--- a/bower.json
+++ b/bower.json
@@ -12,5 +12,11 @@
     "main.scss",
     "main.js"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "o-colors": "^4.0.5",
+    "o-grid": "^4.3.3",
+    "o-typography": "^5.1.0",
+    "o-buttons": "^5.1.0",
+    "o-icons": "^5.4.0"
+  }
 }

--- a/demos/src/banner.mustache
+++ b/demos/src/banner.mustache
@@ -1,0 +1,19 @@
+
+<div class="o-banner" data-o-component="o-banner">
+	<div class="o-banner__inner" data-o-banner-inner="">
+		<div class="o-banner__content o-banner__content--long">
+			<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+		</div>
+		<div class="o-banner__content o-banner__content--short">
+			<p>Try the new compact homepage.</p>
+		</div>
+		<div class="o-banner__actions">
+			<div class="o-banner__action">
+				<a href="#" class="o-banner__button">Try it now</a>
+			</div>
+			<div class="o-banner__action o-banner__action--secondary">
+				<a href="#" class="o-banner__link">Give feedback</a>
+			</div>
+		</div>
+	</div>
+</div>

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-/*global require*/
+
 import './../../main.js';
 
 function initDemos() {

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -1,4 +1,0 @@
-
-<div class="o-banner">
-	<!-- TODO -->
-</div>

--- a/demos/src/imperative.js
+++ b/demos/src/imperative.js
@@ -1,0 +1,17 @@
+
+import Banner from '../../main';
+
+function initDemos() {
+	document.addEventListener('DOMContentLoaded', function() {
+		new Banner(null, {
+			contentLong: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
+			contentShort: 'Try the new compact homepage.',
+			buttonLabel: 'Try it now',
+			buttonUrl: '#try-button',
+			linkLabel: 'Give feedback',
+			linkUrl: '#feedback-link'
+		});
+	});
+}
+
+initDemos();

--- a/demos/src/imperative.mustache
+++ b/demos/src/imperative.mustache
@@ -1,0 +1,2 @@
+
+<!-- Nothing to see here... -->

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 
 import Banner from './src/js/banner';
 
-const constructAll = function() {
+function constructAll () {
 	Banner.init();
 	document.removeEventListener('o.DOMContentLoaded', constructAll);
 };

--- a/main.scss
+++ b/main.scss
@@ -1,11 +1,17 @@
 
+@import 'o-buttons/main';
+@import 'o-colors/main';
+@import 'o-grid/main';
+@import "o-icons/main";
+@import 'o-typography/main';
+
+@import "src/scss/color-use-cases";
 @import "src/scss/variables";
 @import "src/scss/banner";
 
 @if ($o-banner-is-silent == false) {
-	.o-banner {
-		@include oBanner;
-	}
+
+	@include oBanner;
 
 	// Set to silent again to avoid being output twice
 	$o-banner-is-silent: true !global;

--- a/origami.json
+++ b/origami.json
@@ -14,13 +14,19 @@
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
 		"documentClasses": "",
-		"dependencies": ""
+		"dependencies": "o-fonts"
 	},
 	"demos": [
 		{
-			"name": "demo",
-			"template": "demos/src/demo.mustache",
-			"description": "Basic demo"
+			"name": "banner",
+			"template": "demos/src/banner.mustache",
+			"description": "Basic banner"
+		},
+		{
+			"name": "imperative",
+			"template": "demos/src/imperative.mustache",
+			"description": "Imperative banner",
+			"js": "demos/src/imperative.js"
 		}
 	]
 }

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -6,13 +6,132 @@ class Banner {
 
 	/**
 	 * Class constructor.
-	 * @param {HTMLElement} bannerElement - The banner element in the DOM
+	 * @param {HTMLElement} [bannerElement] - The banner element in the DOM
 	 * @param {Object} [options={}] - An options object for configuring the banner
 	 */
 	constructor (bannerElement, options) {
 		this.bannerElement = bannerElement;
-		this.options = options || Banner.getOptions(bannerElement);
-		this.options = Banner.checkOptions(this.options);
+
+		// Default the options
+		const bannerClass = (options && options.bannerClass ? options.bannerClass : 'o-banner');
+		this.options = Object.assign({}, {
+			autoOpen: true,
+
+			bannerClass: bannerClass,
+			bannerClosedClass: `${bannerClass}--closed`,
+			innerClass: `${bannerClass}__inner`,
+			contentClass: `${bannerClass}__content`,
+			contentLongClass: `${bannerClass}__content--long`,
+			contentShortClass: `${bannerClass}__content--short`,
+			actionsClass: `${bannerClass}__actions`,
+			actionClass: `${bannerClass}__action`,
+			actionSecondaryClass: `${bannerClass}__action--secondary`,
+			buttonClass: `${bannerClass}__button`,
+			linkClass: `${bannerClass}__link`,
+			closeButtonClass: `${bannerClass}__close`,
+
+			contentLong: '&hellip;',
+			contentShort: '&hellip;',
+			buttonLabel: 'OK',
+			buttonUrl: '#',
+			linkLabel: 'More info',
+			linkUrl: '#',
+			closeButtonLabel: 'Close'
+
+		}, options || Banner.getOptionsFromDom(bannerElement));
+
+		// Render the banner
+		this.render();
+
+		if (this.options.autoOpen) {
+			this.open();
+		} else {
+			this.close();
+		}
+	}
+
+	/**
+	 * Render the banner.
+	 */
+	render () {
+		// If the banner element is not an HTML Element, build one
+		if (!(this.bannerElement instanceof HTMLElement)) {
+			this.bannerElement = this.buildBannerElement();
+			document.body.appendChild(this.bannerElement);
+		}
+
+		// Select all the elements we need
+		this.innerElement = this.bannerElement.querySelector('[data-o-banner-inner]');
+
+		// Build the close button
+		this.closeButtonElement = this.buildCloseButtonElement();
+		this.innerElement.appendChild(this.closeButtonElement);
+	}
+
+	/**
+	 * Open the banner.
+	 */
+	open () {
+		this.bannerElement.classList.remove(this.options.bannerClosedClass);
+		this.bannerElement.dispatchEvent(new CustomEvent('o.bannerOpened'));
+	}
+
+	/**
+	 * Close the banner.
+	 */
+	close () {
+		this.bannerElement.classList.add(this.options.bannerClosedClass);
+		this.bannerElement.dispatchEvent(new CustomEvent('o.bannerClosed'));
+	}
+
+	/**
+	 * Build a full banner element. This is used when no banner exists in the DOM.
+	 * @returns {HTMLElement} Returns the new banner element
+	 */
+	buildBannerElement () {
+		const bannerElement = document.createElement('div');
+		bannerElement.className = this.options.bannerClass;
+		bannerElement.setAttribute('data-o-component', 'o-banner');
+		bannerElement.innerHTML = `
+			<div class="${this.options.innerClass}" data-o-banner-inner="">
+				<div class="${this.options.contentClass} ${this.options.contentLongClass}">
+					${this.options.contentLong}
+				</div>
+				<div class="${this.options.contentClass} ${this.options.contentShortClass}">
+					${this.options.contentShort}
+				</div>
+				<div class="${this.options.actionsClass}">
+					<div class="${this.options.actionClass}">
+						<a href="${this.options.buttonUrl}" class="${this.options.buttonClass}">${this.options.buttonLabel}</a>
+					</div>
+					<div class="${this.options.actionClass} ${this.options.actionSecondaryClass}">
+						<a href="${this.options.linkUrl}" class="${this.options.linkClass}">${this.options.linkLabel}</a>
+					</div>
+				</div>
+			</div>
+		`;
+		return bannerElement;
+	}
+
+	/**
+	 * Build a close button element.
+	 * @returns {HTMLElement} Returns the new close button element
+	 */
+	buildCloseButtonElement () {
+		const closeButton = document.createElement('a');
+		closeButton.className = this.options.closeButtonClass;
+		closeButton.setAttribute('role', 'button');
+		closeButton.setAttribute('href', '#void');
+		closeButton.setAttribute('aria-label', this.options.closeButtonLabel);
+		closeButton.setAttribute('title', this.options.closeButtonLabel);
+
+		// Add event listeners
+		closeButton.addEventListener('click', event => {
+			this.close();
+			event.preventDefault();
+		});
+
+		return closeButton;
 	}
 
 	/**
@@ -20,7 +139,10 @@ class Banner {
 	 * declaratively, this method is used to extract the data attributes from the DOM.
 	 * @param {HTMLElement} bannerElement - The banner element in the DOM
 	 */
-	static getOptions (bannerElement) {
+	static getOptionsFromDom (bannerElement) {
+		if (!(bannerElement instanceof HTMLElement)) {
+			return {};
+		}
 		return Object.keys(bannerElement.dataset).reduce((options, key) => {
 
 			// Ignore data-o-component
@@ -44,19 +166,10 @@ class Banner {
 	}
 
 	/**
-	 * Check that an options object is valid.
-	 * @param {Object} options - An Object with configuration options for the banner
-	 * @throws {Error} Throws if options are not valid
+	 * Initialise banner components.
+	 * @param {(HTMLElement|String)} rootElement - The root element to intialise banners in, or a CSS selector for the root element
+	 * @param {Object} [options={}] - An options object for configuring the banners
 	 */
-	static checkOptions (options) {
-		return options;
-	}
-
-	/**
- 	 * Initialise banner components.
- 	 * @param {(HTMLElement|String)} rootElement - The root element to intialise banners in, or a CSS selector for the root element
- 	 * @param {Object} [options={}] - An options object for configuring the banners
- 	 */
 	static init (rootElement, options) {
 		if (!rootElement) {
 			rootElement = document.body;

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,0 +1,5 @@
+
+@include oColorsSetUseCase(o-banner, background, 'teal');
+@include oColorsSetUseCase(o-banner, text, 'white');
+@include oColorsSetUseCase(o-banner-link, text, 'white');
+@include oColorsSetUseCase(o-banner-close, text, 'white');

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,2 +1,4 @@
 
 $o-banner-is-silent: true !default;
+$o-banner-spacing: oTypographySpacingSize($units: 10) !default;
+$o-banner-close-button-size: 26 !default;

--- a/src/scss/banner.scss
+++ b/src/scss/banner.scss
@@ -1,6 +1,127 @@
 
-/// Base banner style
-@mixin oBanner {
-	// TODO
-	todo: true;
+@mixin oBannerOuter {
+	@include oColorsFor(o-banner, background text);
+	@include oTypographySans($scale: (default: 1));
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	display: block;
+	width: 100%;
+	padding: oTypographySpacingSize($units: 10) 0;
+}
+
+@mixin oBannerClosed {
+	display: none;
+}
+
+@mixin oBannerInner {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	max-width: map-get($o-grid-layouts, XL);
+	margin: 0 auto;
+}
+
+@mixin oBannerContent {
+	padding: 0 $o-banner-spacing;
+
+	// Remove margins from typographic elements within
+	// the banner, as these mess with the spacing
+	:first-child {
+		margin-top: 0;
+	}
+	:last-child {
+		margin-bottom: 0;
+	}
+}
+
+@mixin oBannerContentLong {
+	@include oGridRespondTo($until: M) {
+		display: none;
+	}
+}
+
+@mixin oBannerContentShort {
+	@include oGridRespondTo($from: M) {
+		display: none;
+	}
+}
+
+@mixin oBannerActions {
+	display: flex;
+	align-items: center;
+}
+
+@mixin oBannerAction {
+	padding-right: $o-banner-spacing;
+}
+
+@mixin oBannerActionSecondary {
+	text-align: right;
+
+	@include oGridRespondTo($until: S) {
+		display: none;
+	}
+}
+
+@mixin oBannerButton {
+	@include oButtons($size: big);
+	@include oButtonsCustomTheme('teal-60', 'white', primary);
+	white-space: nowrap;
+}
+
+@mixin oBannerLink {
+	@include oColorsFor(o-banner-link, text);
+	@include oTypographySans($scale: (default: 0));
+	white-space: nowrap;
+}
+
+@mixin oBannerCloseButton {
+	$close-button-position: round(($o-banner-spacing - $o-banner-close-button-size) / 2);
+	@include oIconsGetIcon('cross', oColorsGetColorFor(o-banner-close, text), $o-banner-close-button-size);
+	display: block;
+	position: absolute;
+	right: $close-button-position;
+	top: -($o-banner-spacing - $close-button-position);
+}
+
+@mixin oBanner($class: 'o-banner') {
+	.#{$class} {
+		@include oBannerOuter;
+
+		&--closed {
+			@include oBannerClosed;
+		}
+		&__inner {
+			@include oBannerInner;
+		}
+		&__content {
+			@include oBannerContent;
+		}
+		&__content--long {
+			@include oBannerContentLong;
+		}
+		&__content--short {
+			@include oBannerContentShort;
+		}
+		&__actions {
+			@include oBannerActions;
+		}
+		&__action {
+			@include oBannerAction;
+		}
+		&__action--secondary {
+			@include oBannerActionSecondary;
+		}
+		&__button {
+			@include oBannerButton;
+		}
+		&__link {
+			@include oBannerLink;
+		}
+		&__close {
+			@include oBannerCloseButton;
+		}
+	}
 }

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -130,7 +130,7 @@ describe('Banner', () => {
 
 		});
 
-		describe('when `options.bannerClass` is specified but no other clases are', () => {
+		describe('when `options.bannerClass` is specified but no other classes are', () => {
 
 			beforeEach(() => {
 

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -1,34 +1,651 @@
 /* eslint-env mocha, sinon, proclaim */
 
 import Banner from './../src/js/banner';
-import proclaim from 'proclaim';
+import * as assert from 'proclaim';
 import sinon from 'sinon/pkg/sinon';
+import mainFixture from './fixture/main';
+
+sinon.assert.expose(assert, {
+	includeFail: false,
+	prefix: ''
+});
 
 describe('Banner', () => {
+	let testArea;
+
+	before(() => {
+		document.body.innerHTML += '<div id="test-area"></div>';
+		testArea = document.getElementById('test-area');
+	});
+
+	afterEach(() => {
+		testArea.innerHTML = '';
+	});
 
 	describe('new Banner(bannerElement, options)', () => {
+		let banner;
+		let bannerCloseStub;
 		let bannerElement;
+		let bannerGetOptionsFromDomStub;
+		let bannerOpenStub;
+		let bannerRenderStub;
 		let options;
 
 		beforeEach(() => {
-			bannerElement = null;
+			testArea.innerHTML = mainFixture;
+
+			// Stub out methods called in constructor
+			bannerGetOptionsFromDomStub = sinon.stub(Banner, 'getOptionsFromDom');
+			bannerRenderStub = sinon.stub(Banner.prototype, 'render');
+			bannerOpenStub = sinon.stub(Banner.prototype, 'open');
+			bannerCloseStub = sinon.stub(Banner.prototype, 'close');
+
+			// Create a banner
+			bannerElement = document.querySelector('[data-o-component=o-banner]');
 			options = {};
-			const banner = new Banner(bannerElement, options);
+			banner = new Banner(bannerElement, options);
+
+			// Restore constructor stubs
+			Banner.getOptionsFromDom.restore();
+			Banner.prototype.render.restore();
+			Banner.prototype.open.restore();
+			Banner.prototype.close.restore();
+
 		});
 
-		it('has some tests');
+		it('stores `bannerElement` in a `bannerElement` property', () => {
+			assert.strictEqual(banner.bannerElement, bannerElement);
+		});
+
+		it('defaults the options and stores them in an `options` property', () => {
+			assert.isObject(banner.options);
+			assert.notStrictEqual(banner.options, options);
+			assert.deepEqual(banner.options, {
+				autoOpen: true,
+				bannerClass: 'o-banner',
+				bannerClosedClass: 'o-banner--closed',
+				innerClass: 'o-banner__inner',
+				contentClass: 'o-banner__content',
+				contentLongClass: 'o-banner__content--long',
+				contentShortClass: 'o-banner__content--short',
+				actionsClass: 'o-banner__actions',
+				actionClass: 'o-banner__action',
+				actionSecondaryClass: 'o-banner__action--secondary',
+				buttonClass: 'o-banner__button',
+				linkClass: 'o-banner__link',
+				closeButtonClass: 'o-banner__close',
+				contentLong: '&hellip;',
+				contentShort: '&hellip;',
+				buttonLabel: 'OK',
+				buttonUrl: '#',
+				linkLabel: 'More info',
+				linkUrl: '#',
+				closeButtonLabel: 'Close'
+			});
+		});
+
+		it('does not extract options from the DOM', () => {
+			assert.notCalled(bannerGetOptionsFromDomStub);
+		});
+
+		it('opens the banner', () => {
+			assert.calledOnce(bannerOpenStub);
+		});
+
+		it('does not close the banner', () => {
+			assert.notCalled(bannerCloseStub);
+		});
+
+		it('renders the banner', () => {
+			assert.calledOnce(bannerRenderStub);
+		});
+
+		describe('when `options.autoOpen` is `false`', () => {
+
+			beforeEach(() => {
+
+				// Stub out methods called in constructor
+				bannerRenderStub = sinon.stub(Banner.prototype, 'render');
+				bannerOpenStub = sinon.stub(Banner.prototype, 'open');
+				bannerCloseStub = sinon.stub(Banner.prototype, 'close');
+
+				// Create a banner
+				options.autoOpen = false;
+				banner = new Banner(bannerElement, options);
+
+				// Restore constructor stubs
+				Banner.prototype.render.restore();
+				Banner.prototype.open.restore();
+				Banner.prototype.close.restore();
+
+			});
+
+			it('does not open the banner', () => {
+				assert.notCalled(bannerOpenStub);
+			});
+
+			it('closes the banner', () => {
+				assert.calledOnce(bannerCloseStub);
+			});
+
+		});
+
+		describe('when `options.bannerClass` is specified but no other clases are', () => {
+
+			beforeEach(() => {
+
+				// Stub out methods called in constructor
+				bannerRenderStub = sinon.stub(Banner.prototype, 'render');
+				bannerOpenStub = sinon.stub(Banner.prototype, 'open');
+
+				// Create a banner
+				options.bannerClass = 'bruce-banner';
+				banner = new Banner(bannerElement, options);
+
+				// Restore constructor stubs
+				Banner.prototype.render.restore();
+				Banner.prototype.open.restore();
+
+			});
+
+			it('defaults the other class options based on the banner class', () => {
+				assert.strictEqual(banner.options.bannerClosedClass, 'bruce-banner--closed');
+				assert.strictEqual(banner.options.innerClass, 'bruce-banner__inner');
+				assert.strictEqual(banner.options.contentClass, 'bruce-banner__content');
+				assert.strictEqual(banner.options.contentLongClass, 'bruce-banner__content--long');
+				assert.strictEqual(banner.options.contentShortClass, 'bruce-banner__content--short');
+				assert.strictEqual(banner.options.actionsClass, 'bruce-banner__actions');
+				assert.strictEqual(banner.options.actionClass, 'bruce-banner__action');
+				assert.strictEqual(banner.options.actionSecondaryClass, 'bruce-banner__action--secondary');
+				assert.strictEqual(banner.options.buttonClass, 'bruce-banner__button');
+				assert.strictEqual(banner.options.linkClass, 'bruce-banner__link');
+			});
+
+		});
+
+		describe('when `options` is not defined', () => {
+
+			beforeEach(() => {
+
+				// Stub out methods called in constructor
+				bannerGetOptionsFromDomStub = sinon.stub(Banner, 'getOptionsFromDom');
+				bannerRenderStub = sinon.stub(Banner.prototype, 'render');
+				bannerOpenStub = sinon.stub(Banner.prototype, 'open');
+
+				bannerGetOptionsFromDomStub.returns({
+					mockOption: 'from dom'
+				});
+
+				// Create a banner
+				banner = new Banner(bannerElement);
+
+				// Restore constructor stubs
+				Banner.getOptionsFromDom.restore();
+				Banner.prototype.render.restore();
+				Banner.prototype.open.restore();
+
+			});
+
+			it('extracts the options from the DOM', () => {
+				assert.calledOnce(bannerGetOptionsFromDomStub);
+				assert.strictEqual(banner.options.mockOption, 'from dom');
+			});
+
+		});
+
+		it('has a render method', () => {
+			assert.isFunction(banner.render);
+		});
+
+		describe('.render()', () => {
+			let mockBannerElement;
+			let mockBannerInnerElement;
+			let mockCloseButtonElement;
+
+			beforeEach(() => {
+				mockBannerElement = document.createElement('div');
+				mockBannerInnerElement = document.createElement('div');
+				mockCloseButtonElement = document.createElement('a');
+
+				sinon.stub(banner, 'buildBannerElement').returns(mockBannerElement);
+				sinon.stub(bannerElement, 'querySelector').returns(mockBannerInnerElement);
+				sinon.stub(mockBannerElement, 'querySelector').returns(mockBannerInnerElement);
+				sinon.stub(banner, 'buildCloseButtonElement').returns(mockCloseButtonElement);
+				sinon.stub(mockBannerInnerElement, 'appendChild');
+
+				banner.render();
+			});
+
+			it('does not build a banner element', () => {
+				assert.notCalled(banner.buildBannerElement);
+			});
+
+			it('selects the inner element and stores it on the `innerElement` property', () => {
+				assert.calledOnce(bannerElement.querySelector);
+				assert.calledWithExactly(bannerElement.querySelector, '[data-o-banner-inner]');
+				assert.strictEqual(banner.innerElement, mockBannerInnerElement);
+			});
+
+			it('builds a close button element and stores it on the `closeButtonElement` property', () => {
+				assert.calledOnce(banner.buildCloseButtonElement);
+				assert.strictEqual(banner.closeButtonElement, mockCloseButtonElement);
+			});
+
+			it('appends the close button element to the inner element', () => {
+				assert.calledOnce(mockBannerInnerElement.appendChild);
+				assert.calledWithExactly(mockBannerInnerElement.appendChild, mockCloseButtonElement);
+			});
+
+			describe('when the `bannerElement` property is not an HTML element', () => {
+
+				beforeEach(() => {
+					banner.bannerElement = null;
+					sinon.stub(document.body, 'appendChild');
+					banner.render();
+				});
+
+				afterEach(() => {
+					document.body.appendChild.restore();
+				});
+
+				it('builds a banner element and stores it on the `bannerElement` property', () => {
+					assert.calledOnce(banner.buildBannerElement);
+					assert.strictEqual(banner.bannerElement, mockBannerElement);
+				});
+
+				it('appends the banner element to the body', () => {
+					assert.calledOnce(document.body.appendChild);
+					assert.calledWithExactly(document.body.appendChild, mockBannerElement);
+				});
+
+			});
+
+		});
+
+		it('has an open method', () => {
+			assert.isFunction(banner.open);
+		});
+
+		describe('.open()', () => {
+
+			beforeEach(() => {
+				sinon.spy(bannerElement.classList, 'remove');
+				sinon.spy(bannerElement, 'dispatchEvent');
+				banner.open();
+			});
+
+			it('removes the banner closed class', () => {
+				assert.calledOnce(bannerElement.classList.remove);
+				assert.calledWith(bannerElement.classList.remove, banner.options.bannerClosedClass);
+			});
+
+			it('dispatches an `o.bannerOpened` event', () => {
+				assert.calledOnce(bannerElement.dispatchEvent);
+				assert.instanceOf(bannerElement.dispatchEvent.firstCall.args[0], CustomEvent);
+				assert.strictEqual(bannerElement.dispatchEvent.firstCall.args[0].type, 'o.bannerOpened');
+			});
+
+		});
+
+		it('has a close method', () => {
+			assert.isFunction(banner.close);
+		});
+
+		describe('.close()', () => {
+
+			beforeEach(() => {
+				sinon.spy(bannerElement.classList, 'add');
+				sinon.spy(bannerElement, 'dispatchEvent');
+				banner.close();
+			});
+
+			it('adds the banner closed class', () => {
+				assert.calledOnce(bannerElement.classList.add);
+				assert.calledWith(bannerElement.classList.add, banner.options.bannerClosedClass);
+			});
+
+			it('dispatches an `o.bannerClosed` event', () => {
+				assert.calledOnce(bannerElement.dispatchEvent);
+				assert.instanceOf(bannerElement.dispatchEvent.firstCall.args[0], CustomEvent);
+				assert.strictEqual(bannerElement.dispatchEvent.firstCall.args[0].type, 'o.bannerClosed');
+			});
+
+		});
+
+		it('has a buildBannerElement method', () => {
+			assert.isFunction(banner.buildBannerElement);
+		});
+
+		describe('.buildBannerElement()', () => {
+			let returnValue;
+
+			beforeEach(() => {
+
+				// Mock options used to test output HTML
+				banner.options.bannerClass = 'mockBannerClass';
+				banner.options.bannerClosedClass = 'mockBannerClosedClass';
+				banner.options.innerClass = 'mockInnerClass';
+				banner.options.contentClass = 'mockContentClass';
+				banner.options.contentLongClass = 'mockContentLongClass';
+				banner.options.contentShortClass = 'mockContentShortClass';
+				banner.options.actionsClass = 'mockActionsClass';
+				banner.options.actionClass = 'mockActionClass';
+				banner.options.actionSecondaryClass = 'mockActionSecondaryClass';
+				banner.options.buttonClass = 'mockButtonClass';
+				banner.options.linkClass = 'mockLinkClass';
+				banner.options.contentLong = 'mockContentLong';
+				banner.options.contentShort = 'mockContentShort';
+				banner.options.buttonLabel = 'mockButtonLabel';
+				banner.options.buttonUrl = 'mockButtonUrl';
+				banner.options.linkLabel = 'mockLinkLabel';
+				banner.options.linkUrl = 'mockLinkUrl';
+
+				returnValue = banner.buildBannerElement();
+			});
+
+			it('returns an HTML element', () => {
+				assert.instanceOf(returnValue, HTMLElement);
+			});
+
+			it('constructs the element HTML based on the given options', () => {
+				assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
+					<div class="mockBannerClass" data-o-component="o-banner">
+						<div class="mockInnerClass" data-o-banner-inner="">
+							<div class="mockContentClass mockContentLongClass">
+								mockContentLong
+							</div>
+							<div class="mockContentClass mockContentShortClass">
+								mockContentShort
+							</div>
+							<div class="mockActionsClass">
+								<div class="mockActionClass">
+									<a href="mockButtonUrl" class="mockButtonClass">mockButtonLabel</a>
+								</div>
+								<div class="mockActionClass mockActionSecondaryClass">
+									<a href="mockLinkUrl" class="mockLinkClass">mockLinkLabel</a>
+								</div>
+							</div>
+						</div>
+					</div>
+				`.replace(/[\t\n]+/g, ''));
+			});
+
+		});
+
+		it('has a buildCloseButtonElement method', () => {
+			assert.isFunction(banner.buildCloseButtonElement);
+		});
+
+		describe('.buildCloseButtonElement()', () => {
+			let returnValue;
+
+			beforeEach(() => {
+
+				// Mock options used to test output HTML
+				banner.options.closeButtonClass = 'mockCloseButtonClass';
+				banner.options.closeButtonLabel = 'mockCloseButtonLabel';
+
+				sinon.stub(HTMLElement.prototype, 'addEventListener');
+
+				returnValue = banner.buildCloseButtonElement();
+			});
+
+			afterEach(() => {
+				HTMLElement.prototype.addEventListener.restore();
+			});
+
+			it('returns an HTML element', () => {
+				assert.instanceOf(returnValue, HTMLElement);
+			});
+
+			it('constructs the element HTML based on the given options', () => {
+				assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
+					<a class="mockCloseButtonClass" role="button" href="#void" aria-label="mockCloseButtonLabel" title="mockCloseButtonLabel"></a>
+				`.replace(/[\t\n]+/g, ''));
+			});
+
+			it('adds a handler for the button click event', () => {
+				assert.calledOnce(returnValue.addEventListener);
+				assert.calledWith(returnValue.addEventListener, 'click');
+				assert.isFunction(returnValue.addEventListener.firstCall.args[1]);
+			});
+
+			describe('click handler', () => {
+				let event;
+
+				beforeEach(() => {
+					const clickHandler = returnValue.addEventListener.firstCall.args[1];
+					event = {
+						preventDefault: sinon.stub()
+					};
+					sinon.stub(banner, 'close');
+					clickHandler(event);
+				});
+
+				it('closes the banner', () => {
+					assert.calledOnce(banner.close);
+				});
+
+				it('prevents the default click behaviour', () => {
+					assert.calledOnce(event.preventDefault);
+				});
+
+			});
+
+		});
+
 	});
 
-	describe('.getOptions(bannerElement)', () => {
-		it('has some tests');
-	});
+	describe('.getOptionsFromDom(bannerElement)', () => {
+		let mockBannerElement;
+		let returnValue;
 
-	describe('.checkOptions(options)', () => {
-		it('has some tests');
+		beforeEach(() => {
+			mockBannerElement = document.createElement('div');
+			mockBannerElement.setAttribute('data-o-component', 'o-banner');
+			mockBannerElement.setAttribute('data-key', 'value');
+			mockBannerElement.setAttribute('data-another-key', 'value');
+			mockBannerElement.setAttribute('data-o-banner-foo', 'bar');
+			mockBannerElement.setAttribute('data-o-banner-json', '{"foo": "bar"}');
+			mockBannerElement.setAttribute('data-o-banner-json-single', '{\'foo\': \'bar\'}');
+			returnValue = Banner.getOptionsFromDom(mockBannerElement);
+		});
+
+		it('returns an object', () => {
+			assert.isObject(returnValue);
+		});
+
+		it('extracts values from data attributes and returns them as object keys', () => {
+			assert.strictEqual(returnValue.key, 'value');
+		});
+
+		it('converts the keys to camel-case', () => {
+			assert.isUndefined(returnValue['another-key']);
+			assert.strictEqual(returnValue.anotherKey, 'value');
+		});
+
+		it('ignores the `data-o-component` attribute', () => {
+			assert.isUndefined(returnValue.oComponent);
+		});
+
+		it('strips "o-banner" from the key', () => {
+			assert.isUndefined(returnValue.oBannerFoo);
+			assert.strictEqual(returnValue.foo, 'bar');
+		});
+
+		it('parses the key as JSON if it\'s valid', () => {
+			assert.isObject(returnValue.json);
+			assert.deepEqual(returnValue.json, {
+				foo: 'bar'
+			});
+		});
+
+		it('parses the key as JSON even if single quotes are used', () => {
+			assert.isObject(returnValue.jsonSingle);
+			assert.deepEqual(returnValue.jsonSingle, {
+				foo: 'bar'
+			});
+		});
+
+		describe('when `bannerElement` is not an HTML element', () => {
+			let returnValue;
+
+			beforeEach(() => {
+				returnValue = Banner.getOptionsFromDom(null);
+			});
+
+			it('returns an empty object', () => {
+				assert.isObject(returnValue);
+				assert.deepEqual(returnValue, {});
+			});
+
+		});
+
 	});
 
 	describe('.init(rootElement, options)', () => {
-		it('has some tests');
+		let mockRootElement;
+		let options;
+		let returnValue;
+
+		beforeEach(() => {
+			sinon.stub(document, 'querySelector');
+			sinon.stub(Banner.prototype, 'render');
+			sinon.stub(Banner.prototype, 'open');
+			mockRootElement = document.createElement('div');
+			options = {
+				mockOption: 'test'
+			};
+		});
+
+		afterEach(() => {
+			document.querySelector.restore();
+			Banner.prototype.render.restore();
+			Banner.prototype.open.restore();
+		});
+
+		describe('when `rootElement` is an HTML element with a `data-o-component` attribute set to "o-banner"', () => {
+
+			beforeEach(() => {
+				mockRootElement.setAttribute('data-o-component', 'o-banner');
+				returnValue = Banner.init(mockRootElement, options);
+			});
+
+			it('does not query the the document', () => {
+				assert.notCalled(document.querySelector);
+			});
+
+			it('creates a new Banner instance with the passed in arguments, and returns it', () => {
+				assert.instanceOf(returnValue, Banner);
+				assert.strictEqual(returnValue.bannerElement, mockRootElement);
+				assert.strictEqual(returnValue.options.mockOption, 'test');
+			});
+
+		});
+
+		describe('when `rootElement` is an HTML element with no `data-o-component` attribute', () => {
+			let mockBanner1;
+			let mockBanner2;
+			let mockNotBanner;
+
+			beforeEach(() => {
+				mockBanner1 = document.createElement('div');
+				mockBanner1.setAttribute('data-o-component', 'o-banner');
+				mockBanner2 = document.createElement('div');
+				mockBanner2.setAttribute('data-o-component', 'o-banner');
+				mockNotBanner = document.createElement('div');
+				mockRootElement.appendChild(mockBanner1);
+				mockRootElement.appendChild(mockBanner2);
+				mockRootElement.appendChild(mockNotBanner);
+				sinon.spy(mockRootElement, 'querySelectorAll');
+				returnValue = Banner.init(mockRootElement, options);
+			});
+
+			it('does not query the the document', () => {
+				assert.notCalled(document.querySelector);
+			});
+
+			it('queries the `rootElement` for banner elements', () => {
+				assert.calledOnce(mockRootElement.querySelectorAll);
+				assert.calledWithExactly(mockRootElement.querySelectorAll, '[data-o-component="o-banner"]');
+			});
+
+			it('creates a new Banner instance with each banner element in `rootElement`, and returns an array of them', () => {
+				assert.isArray(returnValue);
+				assert.lengthEquals(returnValue, 2);
+				assert.instanceOf(returnValue[0], Banner);
+				assert.strictEqual(returnValue[0].bannerElement, mockBanner1);
+				assert.strictEqual(returnValue[0].options.mockOption, 'test');
+				assert.instanceOf(returnValue[1], Banner);
+				assert.strictEqual(returnValue[1].bannerElement, mockBanner2);
+				assert.strictEqual(returnValue[1].options.mockOption, 'test');
+			});
+
+		});
+
+		describe('when `rootElement` is defined, but is not an HTML element', () => {
+			let foundElement;
+
+			beforeEach(() => {
+				foundElement = document.createElement('div');
+				foundElement.setAttribute('data-o-component', 'o-banner');
+				document.querySelector.returns(foundElement);
+				returnValue = Banner.init('mock-selector', options);
+			});
+
+			it('queries the DOM using `rootElement` as a selector', () => {
+				assert.calledOnce(document.querySelector);
+				assert.calledWithExactly(document.querySelector, 'mock-selector');
+			});
+
+			it('creates a new Banner instance with the found element, and returns it', () => {
+				assert.instanceOf(returnValue, Banner);
+				assert.strictEqual(returnValue.bannerElement, foundElement);
+				assert.strictEqual(returnValue.options.mockOption, 'test');
+			});
+
+		});
+
+		describe('when `rootElement` is not defined', () => {
+			let mockBanner1;
+			let mockBanner2;
+
+			beforeEach(() => {
+				mockBanner1 = document.createElement('div');
+				mockBanner1.setAttribute('data-o-component', 'o-banner');
+				mockBanner2 = document.createElement('div');
+				mockBanner2.setAttribute('data-o-component', 'o-banner');
+				testArea.appendChild(mockBanner1);
+				testArea.appendChild(mockBanner2);
+				sinon.spy(document.body, 'querySelectorAll');
+				returnValue = Banner.init(null, options);
+			});
+
+			afterEach(() => {
+				document.body.querySelectorAll.restore();
+			});
+
+			it('does not query the the document', () => {
+				assert.notCalled(document.querySelector);
+			});
+
+			it('queries `document.body` for banner elements', () => {
+				assert.calledOnce(document.body.querySelectorAll);
+				assert.calledWithExactly(document.body.querySelectorAll, '[data-o-component="o-banner"]');
+			});
+
+			it('creates a new Banner instance with each banner element in `document.body`, and returns an array of them', () => {
+				assert.isArray(returnValue);
+				assert.lengthEquals(returnValue, 2);
+				assert.instanceOf(returnValue[0], Banner);
+				assert.strictEqual(returnValue[0].bannerElement, mockBanner1);
+				assert.strictEqual(returnValue[0].options.mockOption, 'test');
+				assert.instanceOf(returnValue[1], Banner);
+				assert.strictEqual(returnValue[1].bannerElement, mockBanner2);
+				assert.strictEqual(returnValue[1].options.mockOption, 'test');
+			});
+		});
+
 	});
 
 });

--- a/test/fixture/main.js
+++ b/test/fixture/main.js
@@ -1,0 +1,25 @@
+
+const mainFixture = `
+
+<div class="o-banner" data-o-component="o-banner">
+	<div class="o-banner__inner" data-o-banner-inner="">
+		<div class="o-banner__content o-banner__content--long">
+			long content
+		</div>
+		<div class="o-banner__content o-banner__content--short">
+			short content
+		</div>
+		<div class="o-banner__actions">
+			<div class="o-banner__action">
+				<a href="#" class="o-banner__button">button label</a>
+			</div>
+			<div class="o-banner__action o-banner__action--secondary">
+				<a href="#" class="o-banner__link">link label</a>
+			</div>
+		</div>
+	</div>
+</div>
+
+`;
+
+export default mainFixture;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,11 +1,41 @@
 /* eslint-env mocha, sinon, proclaim */
 
 import Banner from './../main';
-import proclaim from 'proclaim';
+import {default as BannerSrc} from './../src/js/banner';
+import * as assert from 'proclaim';
 import sinon from 'sinon/pkg/sinon';
+
+sinon.assert.expose(assert, {
+	includeFail: false,
+	prefix: ''
+});
 
 describe('main', () => {
 
-	// TODO see o-tooltip test/origami.test.js
+	beforeEach(() => {
+		sinon.stub(Banner, 'init');
+		sinon.spy(document, 'removeEventListener');
+	});
+
+	afterEach(() => {
+		Banner.init.restore();
+		document.removeEventListener.restore();
+	});
+
+	it('exports the Banner class', () => {
+		assert.isFunction(Banner);
+		assert.strictEqual(Banner, BannerSrc);
+	});
+
+	it('should auto-initialize banners', done => {
+		document.addEventListener('o.DOMContentLoaded', () => {
+			assert.calledOnce(Banner.init);
+			assert.calledWithExactly(Banner.init);
+			assert.calledOnce(document.removeEventListener);
+			assert.calledWith(document.removeEventListener, 'o.DOMContentLoaded');
+			done();
+		});
+		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+	});
 
 });


### PR DESCRIPTION
This includes a basic version of the full width banner. The close button
works, and the banner can be initialised either declaratively or
imperatively.

What's missing from here is the documentation and the "lionel slider"
style of banner, these will be added separately. The unit tests are all
in place, but we're missing Pa11y tests. Again, these will be added
later once all of the CSS is complete.

@alicebartlett: sorry for the large PR, I'll be splitting them into smaller
chunks from now on, but I wanted to get actual working code in for
the first one.