### PR TITLE
Ensure demos display correctly in the registry

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -4,6 +4,8 @@ $o-banner-is-silent: false;
 
 body {
 	font-family: MetricWeb;
+	min-height: 350px;
+	background-color: oColorsGetPaletteColor('paper');
 }
 
 .demo-buttons {


### PR DESCRIPTION
Currently the demo boxes are too small to display the full banners. I've also set the body background to paper.