### PR TITLE
Tweak the small banner for tablet-size screens

### DIFF
--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -22,6 +22,9 @@
 	padding: $_o-banner-spacing;
 	max-width: oGridColspan(5);
 
+	@include oGridRespondTo($until: L) {
+		max-width: oGridColspan(7);
+	}
 	@include oGridRespondTo($until: M) {
 		max-width: oGridColspan(8);
 	}


### PR DESCRIPTION
This resolves #15. I sat with @draysonandstock to work out the best
point to resize at, now we see fewer super-squished sentences.