### PR TITLE
Remove the dotted underline under the close button

### DIFF
--- a/src/scss/_banner.scss
+++ b/src/scss/_banner.scss
@@ -148,6 +148,10 @@
 	position: absolute;
 	right: $close-button-position;
 	top: $close-button-position;
+
+	// Note: this is to combat the default link styles often
+	// provided by o-typography
+	border: 0;
 }
 
 @mixin oBanner($class: 'o-banner', $themes: 'all') {


### PR DESCRIPTION
This appears when o-typography's link styles are applied globally,
something that's done across most of FT.com

Resolves #28