### PR TITLE
Increase o-icon semver range.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "o-grid": "^4.3.3",
     "o-typography": "^5.2.0",
     "o-buttons": "^5.1.0",
-    "o-icons": "^5.4.0",
+    "o-icons": ">=4.0.0 <6",
     "o-visual-effects": "^2.0.3"
   }
 }

--- a/src/scss/_banner.scss
+++ b/src/scss/_banner.scss
@@ -143,7 +143,7 @@
 
 @mixin oBannerCloseButton {
 	$close-button-position: round(($_o-banner-spacing - $_o-banner-close-button-size) / 2);
-	@include oIconsGetIcon('cross', oColorsGetColorFor(o-banner-close, text), $_o-banner-close-button-size);
+	@include oIconsGetIcon('cross', oColorsGetColorFor(o-banner-close, text), $_o-banner-close-button-size, $iconset-version: 1);
 	display: block;
 	position: absolute;
 	right: $close-button-position;

--- a/src/scss/themes/_marketing-primary.scss
+++ b/src/scss/themes/_marketing-primary.scss
@@ -41,7 +41,7 @@
 }
 
 @mixin oBannerThemeMarketingPrimaryCloseButton {
-	@include oIconsGetIcon('cross', oColorsGetColorFor(o-banner-marketing-primary-close, text), $_o-banner-close-button-size);
+	@include oIconsGetIcon('cross', oColorsGetColorFor(o-banner-marketing-primary-close, text), $_o-banner-close-button-size, $iconset-version: 1);
 }
 
 @mixin oBannerThemeMarketingPrimary($class: 'o-banner') {

--- a/src/scss/themes/_marketing.scss
+++ b/src/scss/themes/_marketing.scss
@@ -39,7 +39,7 @@
 }
 
 @mixin oBannerThemeMarketingCloseButton {
-	@include oIconsGetIcon('cross', oColorsGetColorFor(o-banner-marketing-close, text), $_o-banner-close-button-size);
+	@include oIconsGetIcon('cross', oColorsGetColorFor(o-banner-marketing-close, text), $_o-banner-close-button-size, $iconset-version: 1);
 }
 
 @mixin oBannerThemeMarketing($class: 'o-banner') {


### PR DESCRIPTION
This improves the compatibility of `o-banner` with other components which depend on `o-icon`.

Issue:
```
Unable to find a suitable version for o-icons, please choose one by typing one of the numbers below:
    1) o-icons#>=4.4.2 <6 which resolved to 4.4.6 and is required by o-buttons#5.8.2, o-cookie-message#3.0.6, o-expander#4.4.4, o-footer#6.0.8, o-header#7.2.7, o-teaser#2.1.15, o-teaser-collection#2.1.1, o-video#4.1.6
    2) o-icons#^4.0.0 which resolved to 4.4.6 and is required by o-comment-ui#4.2.2
    3) o-icons#>=4.0.0 <6.0.0 which resolved to 4.4.6 and is required by o-overlay#2.1.5
    4) o-icons#>=4.0.0 <6 which resolved to 5.6.0 and is required by n-desktop-app-banner#2.0.2, n-invite-colleagues#3.0.4, n-newsletter-signup#3.1.3, n-sliding-popup#2.0.0, n-ui-foundations#3.0.0, next-article, o-comments#4.0.7, o-quote#2.1.3
    5) o-icons#^5.4.0 which resolved to 5.6.0 and is required by o-banner#1.4.0
```

Solution:
<img width="1440" alt="screen shot 2018-01-05 at 12 58 55" src="https://user-images.githubusercontent.com/10405691/34610260-3b1196c4-f218-11e7-81b6-69c32d99d7a7.png">
<img width="866" alt="screen shot 2018-01-05 at 12 57 38" src="https://user-images.githubusercontent.com/10405691/34610266-4426b9ec-f218-11e7-8648-dbb6670a0617.png">
