### PR TITLE
fixes bug with positioning

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -18,3 +18,13 @@ body {
 .o-banner--static {
 	position: static !important; // sass-lint:disable-line no-important
 }
+
+.container {
+	height: 100vh;
+}
+
+.linkage {
+	position: relative;
+	top: 85%;
+	left: 55%;
+}

--- a/demos/src/small.mustache
+++ b/demos/src/small.mustache
@@ -1,3 +1,6 @@
+<div class="container">
+<a href="#" class="linkage">link lols</a>	
+</div>
 
 <div class="o-banner o-banner--small" data-o-component="o-banner">
 	<div class="o-banner__outer">

--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -1,4 +1,3 @@
-
 @mixin oBannerThemeSmallBase {
 	bottom: $_o-banner-spacing / 2;
 
@@ -8,9 +7,6 @@
 }
 
 @mixin oBannerThemeSmallOuter {
-	width: auto;
-	max-width: map-get($o-grid-layouts, XL);
-	margin: 0 auto;
 	background-color: transparent;
 	box-shadow: none;
 }
@@ -19,20 +15,30 @@
 	@include oColorsFor(o-banner, background);
 	@include oVisualEffectsShadowsElevation('high');
 	@include oTypographySans($scale: 2);
-	display: block;
-	margin: 0 $_o-banner-spacing / 2;
-	padding: $_o-banner-spacing;
-	max-width: oGridColspan(6);
 
-	@include oGridRespondTo($until: L) {
-		max-width: oGridColspan(7);
+	display: block;
+	padding: $_o-banner-spacing;
+
+	position: absolute;
+	right: calc(#{100% - oGridColspan(6)} - #{oGridGutter(M)});
+	left: calc(#{oGridColspan(2)} + #{oGridGutter(M) * 2});
+	bottom: 100%;
+
+
+	@include oGridRespondTo($until: XL) {
+		right: calc(#{100% - oGridColspan(6)}});
+		left: oGridGutter(M);
 	}
+
 	@include oGridRespondTo($until: M) {
-		max-width: oGridColspan(8);
+		right: calc(#{100% - oGridColspan(8)} - #{oGridGutter(M)});
+		left: oGridGutter(M);
 	}
+
 	@include oGridRespondTo($until: S) {
-		max-width: 100%;
-		margin: 0;
+		right: 0;
+		left: 0;
+		bottom: 0;
 	}
 }
 

--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -26,7 +26,7 @@
 
 
 	@include oGridRespondTo($until: XL) {
-		right: calc(#{100% - oGridColspan(6)}});
+		right: calc(#{100% - oGridColspan(6)});
 		left: oGridGutter(M);
 	}
 


### PR DESCRIPTION
This fixes #19 

There is a slight caveat that at `L+` breakpoints the alignment isn't entirely correct, because we can't use the grid or margins to set the container for the small banner, as it is what was blocking the interaction with the components behind it (which means we can't set `margin: 0 auto` which is how it was being aligned before).

This is what it looks like on a desktop — if there are any ideas as to how to Math the margins into submission, please let me know. 
![o-banner-after](https://user-images.githubusercontent.com/16777943/35270062-d1ddffaa-0025-11e8-804b-372bfa5b1b1e.gif)


(This is what the small banner currently looks like)
![o-banner-before](https://user-images.githubusercontent.com/16777943/35269999-9b5f48a8-0025-11e8-9a43-7987c7d62201.gif)
