### PR TITLE
use n-ui-foundations to import deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,11 +13,6 @@
     "main.js"
   ],
   "dependencies": {
-    "o-colors": "^4.1.1",
-    "o-grid": "^4.3.3",
-    "o-typography": "^5.2.0",
-    "o-buttons": "^5.1.0",
-    "o-icons": ">=4.0.0 <6",
-    "o-visual-effects": "^2.0.3"
+    "n-ui-foundations": "^3.0.0"
   }
 }


### PR DESCRIPTION
This component is mainly used on ft.com via https://github.com/Financial-Times/n-messaging-client/
When it is imported into next apps we can end up in dependency resolution hell.
If we use `n-ui-foundations` across the board to import these deps, then we can help ensure we don't get resolution problems all over.

I appreciate that this is a `o-` component and we may not be for this approach however.