### PR TITLE
Make the small screen banner consistent

### DIFF
--- a/demos/src/small.mustache
+++ b/demos/src/small.mustache
@@ -12,6 +12,9 @@
 				<div class="o-banner__action">
 					<a href="#" class="o-banner__button">Try it now</a>
 				</div>
+				<div class="o-banner__action o-banner__action--secondary">
+					<a href="#" class="o-banner__link">Give feedback</a>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/src/scss/_banner.scss
+++ b/src/scss/_banner.scss
@@ -29,6 +29,12 @@
 	margin: 0 auto;
 	padding: $_o-banner-spacing 0;
 	box-sizing: border-box;
+
+	@include oGridRespondTo($until: S) {
+		@include oTypographySans($scale: 0);
+		display: block;
+		padding: $_o-banner-spacing;
+	}
 }
 
 @mixin oBannerContent {
@@ -64,6 +70,10 @@
 		li:before {
 			color: inherit;
 		}
+	}
+
+	@include oGridRespondTo($until: S) {
+		padding: 0;
 	}
 }
 
@@ -103,17 +113,27 @@
 @mixin oBannerActions {
 	display: flex;
 	align-items: center;
+
+	@include oGridRespondTo($until: S) {
+		display: block;
+		margin-top: oTypographySpacingSize(6);
+	}
 }
 
 @mixin oBannerAction {
 	padding-right: $_o-banner-spacing;
+
+	@include oGridRespondTo($until: S) {
+		padding: 0;
+	}
 }
 
 @mixin oBannerActionSecondary {
 	text-align: right;
 
 	@include oGridRespondTo($until: S) {
-		display: none;
+		text-align: left;
+		margin-top: $_o-banner-spacing / 4;
 	}
 }
 


### PR DESCRIPTION
The regular banner now looks like the small banner at the smallest
screen size, this is because the link needs to be visible for legal
reasons in a lot of cases, and gives us more room.

Currently there's a bit of copy/paste in here, but I didn't want to use
themed mixins inside the non-themed ones. Open to ideas if there's a
nicer way of doing this.

This resolves #40

<table>
    <thead>
        <tr>
            <th>Small banner at small screen size</th>
            <th>Regular banner at small screen size</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td><img width="351" alt="Small banner at small screen size" src="https://user-images.githubusercontent.com/138944/36144120-fb2e3d36-10a4-11e8-8945-802fa943672e.png"/></td>
            <td><img width="350" alt="Regular banner at small screen size" src="https://user-images.githubusercontent.com/138944/36144124-fdd4b98e-10a4-11e8-8ab4-4ab5eb3b75cb.png"/></td>
        </tr>
    </tbody>
</table>
