### PR TITLE
Add a compact theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ o-banner includes mixins that you can use if you'd rather not have origami class
 The `$themes` parameter can be either `all` or a list of [themes](#themes) to include:
 
 ```scss
-@include oBanner($themes: ('small', 'marketing'));
+@include oBanner($themes: ('small', 'compact', 'marketing'));
 ```
 
 ### Themes
@@ -150,6 +150,7 @@ The `$themes` parameter can be either `all` or a list of [themes](#themes) to in
 o-banner is themeable, and has the following built-in themes, which can be used in combination with eachother:
 
   - `small`: Display the banner in the bottom left of the screen at a smaller size, rather than full width
+  - `compact`: Display the banner in the bottom left like the `small` theme, but with tighter spacing and smaller typography
   - `marketing`: Use the marketing colours for the banner
 
 In the markup, these can be applied as classes alongside the `o-banner class`. They are exposed as modifiers:

--- a/demos/src/compact.mustache
+++ b/demos/src/compact.mustache
@@ -1,0 +1,21 @@
+
+<div class="o-banner o-banner--compact" data-o-component="o-banner">
+	<div class="o-banner__outer">
+		<div class="o-banner__inner" data-o-banner-inner="">
+			<div class="o-banner__content">
+				<header class="o-banner__heading">
+					<h1>FT Compact</h1>
+				</header>
+				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+			</div>
+			<div class="o-banner__actions">
+				<div class="o-banner__action">
+					<a href="#" class="o-banner__button">Try it now</a>
+				</div>
+				<div class="o-banner__action o-banner__action--secondary">
+					<a href="#" class="o-banner__link">Give feedback</a>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/main.scss
+++ b/main.scss
@@ -15,6 +15,7 @@
 @import "src/scss/themes/marketing-secondary";
 @import "src/scss/themes/marketing-primary";
 @import "src/scss/themes/small";
+@import "src/scss/themes/compact";
 
 @if ($o-banner-is-silent == false) {
 

--- a/origami.json
+++ b/origami.json
@@ -40,6 +40,12 @@
 			"description": "Marketing banner theme"
 		},
 		{
+			"title": "Compact",
+			"name": "compact",
+			"template": "demos/src/compact.mustache",
+			"description": "Compact banner theme"
+		},
+		{
 			"title": "Imperative",
 			"name": "imperative",
 			"template": "demos/src/imperative.mustache",

--- a/src/scss/_banner.scss
+++ b/src/scss/_banner.scss
@@ -34,6 +34,7 @@
 		@include oTypographySans($scale: 0);
 		display: block;
 		padding: $_o-banner-spacing;
+		padding-top: oTypographySpacingSize($units: 7);
 	}
 }
 
@@ -71,6 +72,14 @@
 			color: inherit;
 		}
 	}
+	a {
+		@include oTypographyLinkCustom(
+			$baseColor: oColorsGetUseCase(o-banner-link, text),
+			$hoverColor: oColorsGetUseCase(o-banner-link, text),
+			$outlineColor: oColorsGetUseCase(o-banner-link, text),
+			$backgroundColor: oColorsGetUseCase(o-banner, background)
+		);
+	}
 
 	@include oGridRespondTo($until: S) {
 		padding: 0;
@@ -99,7 +108,7 @@
 		margin-bottom: 0;
 	}
 	&:after {
-		@include oTypographyMargin($top: 3, $bottom: 3);
+		@include oTypographyMargin($top: 2, $bottom: 4);
 		content: '';
 		display: block;
 		width: 100px;
@@ -111,11 +120,13 @@
 }
 
 @mixin oBannerActions {
+	@include oTypographySans($scale: 2);
 	display: flex;
 	align-items: center;
 
 	@include oGridRespondTo($until: S) {
-		display: block;
+		flex-direction: column;
+		align-items: flex-start;
 		margin-top: oTypographySpacingSize(6);
 	}
 }
@@ -124,15 +135,12 @@
 	padding-right: $_o-banner-spacing;
 
 	@include oGridRespondTo($until: S) {
-		padding: 0;
+		padding-right: 0;
 	}
 }
 
 @mixin oBannerActionSecondary {
-	text-align: right;
-
 	@include oGridRespondTo($until: S) {
-		text-align: left;
 		margin-top: $_o-banner-spacing / 4;
 	}
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -13,5 +13,7 @@
 
 	} @else if $theme == 'small' {
 		@include oBannerThemeSmall($class);
+	} @else if $theme == 'compact' {
+		@include oBannerThemeCompact($class);
 	}
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,4 +3,4 @@ $o-banner-is-silent: true !default;
 
 $_o-banner-spacing: oTypographySpacingSize($units: 10) !default;
 $_o-banner-close-button-size: 26 !default;
-$_o-banner-themes: ('small', 'marketing', 'marketing-secondary', 'marketing-primary'); // order is important
+$_o-banner-themes: ('small', 'compact', 'marketing', 'marketing-secondary', 'marketing-primary'); // order is important

--- a/src/scss/themes/_compact.scss
+++ b/src/scss/themes/_compact.scss
@@ -1,0 +1,135 @@
+
+@mixin oBannerThemeCompactBase {
+	width: 100%;
+	margin: 0;
+
+	@include oGridRespondTo(S) {
+		width: oGridColspan(7);
+		margin: $_o-banner-spacing / 2;
+	}
+
+	@include oGridRespondTo(M) {
+		width: oGridColspan(6);
+	}
+
+	@include oGridRespondTo(L) {
+		width: oGridColspan(5);
+	}
+
+	@include oGridRespondTo(XL) {
+		width: map-get($o-grid-layouts, XL) / 2.5; // width is 40% grid
+		left: calc((100vw - #{map-get($o-grid-layouts, XL)}) / 2); // ((viewport - grid width) / 2)
+	}
+}
+
+@mixin oBannerThemeCompactOuter {
+	background-color: transparent;
+	box-shadow: none;
+}
+
+@mixin oBannerThemeCompactInner {
+	@include oColorsFor(o-banner, background);
+	@include oVisualEffectsShadowsElevation('high');
+	@include oTypographySans($scale: 0);
+	display: block;
+	padding: $_o-banner-spacing;
+	padding-top: oTypographySpacingSize($units: 7);
+	max-width: none;
+}
+
+@mixin oBannerThemeCompactContent {
+	padding: 0;
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	ul li {
+		@include oTypographySans($scale: 2);
+	}
+	@include oGridRespondTo($until: M) {
+		&,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6,
+		ul li {
+			@include oTypographySans($scale: 0);
+		}
+	}
+}
+
+@mixin oBannerThemeCompactHeading {
+	@include oTypographySans($scale: 2);
+	padding-right: $_o-banner-spacing;
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		@include oTypographySans($scale: 3);
+		@include oTypographyBold($font: 'sans');
+	}
+	@include oGridRespondTo($until: M) {
+		&,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			@include oTypographySans($scale: 2);
+		}
+	}
+	&:after {
+		@include oTypographyMargin($top: 1, $bottom: 3);
+		width: 60px;
+		border-bottom: oTypographySpacingSize(1) solid;
+	}
+}
+
+@mixin oBannerThemeCompactActions {
+	@include oBannerThemeSmallActions;
+}
+
+@mixin oBannerThemeCompactAction {
+	@include oBannerThemeSmallAction;
+}
+
+@mixin oBannerThemeCompactActionSecondary {
+	@include oBannerThemeSmallActionSecondary;
+}
+
+@mixin oBannerThemeCompact($class: 'o-banner') {
+	.#{$class}--compact {
+		@include oBannerThemeCompactBase;
+
+		.#{$class}__outer {
+			@include oBannerThemeCompactOuter;
+		}
+		.#{$class}__inner {
+			@include oBannerThemeCompactInner;
+		}
+		.#{$class}__content {
+			@include oBannerThemeCompactContent;
+		}
+		.#{$class}__heading {
+			@include oBannerThemeCompactHeading;
+		}
+		.#{$class}__actions {
+			@include oBannerThemeCompactActions;
+		}
+		.#{$class}__action {
+			@include oBannerThemeCompactAction;
+		}
+		.#{$class}__action--secondary {
+			@include oBannerThemeCompactActionSecondary;
+		}
+	}
+}

--- a/src/scss/themes/_marketing.scss
+++ b/src/scss/themes/_marketing.scss
@@ -12,6 +12,17 @@
 	@include oColorsFor(o-banner-marketing, background);
 }
 
+@mixin oBannerThemeMarketingContent() {
+	a {
+		@include oTypographyLinkCustom(
+			$baseColor: oColorsGetUseCase(o-banner-marketing-link, text),
+			$hoverColor: oColorsGetUseCase(o-banner-marketing-link, text),
+			$outlineColor: oColorsGetUseCase(o-banner-marketing-link, text),
+			$backgroundColor: oColorsGetUseCase(o-banner-marketing, background)
+		);
+	}
+}
+
 @mixin oBannerThemeMarketingHeading {
 	&:after {
 		border-color: oColorsGetColorFor(o-banner-marketing-heading-rule, background);
@@ -47,6 +58,9 @@
 		.#{$class}__outer {
 			@include oBannerThemeMarketingOuter;
 		}
+		.#{$class}__content {
+			@include oBannerThemeMarketingContent;
+		}
 		.#{$class}__heading {
 			@include oBannerThemeMarketingHeading;
 		}
@@ -60,8 +74,9 @@
 			@include oBannerThemeMarketingCloseButton;
 		}
 
-		// When combined with the "small" theme
-		&.#{$class}--small {
+		// When combined with the "small" and "condensed" themes
+		&.#{$class}--small,
+		&.#{$class}--condensed {
 			.#{$class}__outer {
 				@include oBannerThemeMarketingSmallOuter;
 			}

--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -33,6 +33,7 @@
 	@include oTypographySans($scale: 2);
 	display: block;
 	padding: $_o-banner-spacing;
+	padding-top: oTypographySpacingSize($units: 7);
 	max-width: none;
 }
 
@@ -64,6 +65,8 @@
 
 @mixin oBannerThemeSmallHeading {
 	@include oTypographySans($scale: 4);
+	padding-right: $_o-banner-spacing;
+
 	h1,
 	h2,
 	h3,
@@ -81,23 +84,29 @@
 		h4,
 		h5,
 		h6 {
-			@include oTypographySans($scale: 2);
+			@include oTypographySans($scale: 3);
 		}
 	}
 }
 
 @mixin oBannerThemeSmallActions {
-	display: block;
 	margin-top: oTypographySpacingSize(6);
+
+	@include oGridRespondTo($until: M) {
+		flex-direction: column;
+		align-items: flex-start;
+		margin-top: oTypographySpacingSize(6);
+	}
 }
 
 @mixin oBannerThemeSmallAction {
-	padding: 0;
+	padding-right: $_o-banner-spacing / 2;
 }
 
 @mixin oBannerThemeSmallActionSecondary {
-	text-align: left;
-	margin-top: $_o-banner-spacing / 4;
+	@include oGridRespondTo($until: M) {
+		margin-top: $_o-banner-spacing / 4;
+	}
 }
 
 @mixin oBannerThemeSmall($class: 'o-banner') {


### PR DESCRIPTION
This adds a compact theme and refactors some of the other themes a
little in order to keep the different banners more consistent.

The compact theme vs small theme, to get an idea of sizing:

<table>
    <tr>
        <th>Compact banner</th>
        <th>Small banner</th>
    </tr>
    <tr>
        <td><img src="https://user-images.githubusercontent.com/138944/41149592-e13c5160-6b03-11e8-8b3a-e956fec7ea99.png" alt="Compact banner"/></td>
        <td><img src="https://user-images.githubusercontent.com/138944/41149600-e54909c4-6b03-11e8-84ab-8c25549229db.png" alt="Small banner"/></td>
    </tr>
</table>

At smaller screen sizes, the banners are all pretty much the same:

<table>
    <tr>
        <th>Compact banner</th>
        <th>Small banner</th>
        <th>Regular banner</th>
    </tr>
    <tr>
        <td><img src="https://user-images.githubusercontent.com/138944/41149790-60a32500-6b04-11e8-83bf-3e75e0dba16a.png" alt="Compact banner"/></td>
        <td><img src="https://user-images.githubusercontent.com/138944/41149791-60ba4744-6b04-11e8-9e8f-9d71195d0594.png" alt="Small banner"/></td>
        <td><img src="https://user-images.githubusercontent.com/138944/41149792-60d14160-6b04-11e8-92fc-05e45e785514.png" alt="Regular banner"/></td>
    </tr>
</table>

Here's what it looks like at different sizes:

![banner-resize](https://user-images.githubusercontent.com/138944/41150708-91532d1a-6b06-11e8-8c02-4dce6cad823b.gif)

