### PR TITLE
Add a product theme and change the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ o-banner includes mixins that you can use if you'd rather not have origami class
 The `$themes` parameter can be either `all` or a list of [themes](#themes) to include:
 
 ```scss
-@include oBanner($themes: ('small', 'compact', 'marketing'));
+@include oBanner($themes: ('small', 'compact', 'marketing', 'product'));
 ```
 
 ### Themes
@@ -175,6 +175,8 @@ const myBanner = new oBanner({
 ### Migrating from v1 to v2
 
 V2 of o-banner removes and renames several themes. This includes the removal of associated mixins and variables. The removed themes are `marketing-primary` and `marketing-secondary`. This should be replaced with `marketing`.
+
+As well as this, the default teal theme has been replaced with a white theme. The old default teal theme is now named `product`.
 
 ---
 

--- a/demos/src/all.mustache
+++ b/demos/src/all.mustache
@@ -1,0 +1,18 @@
+
+<div class="demo-buttons">
+	<button class="demo-button" id="banner-standard">Standard banner</button>
+	<button class="demo-button" id="banner-small">Small banner</button>
+	<button class="demo-button" id="banner-compact">Compact banner</button>
+</div>
+
+<div class="demo-buttons">
+	<button class="demo-button" id="banner-marketing">Marketing banner</button>
+	<button class="demo-button" id="banner-marketing-small">Marketing banner (small)</button>
+	<button class="demo-button" id="banner-marketing-compact">Marketing banner (compact)</button>
+</div>
+
+<div class="demo-buttons">
+	<button class="demo-button" id="banner-product">Product banner</button>
+	<button class="demo-button" id="banner-product-small">Product banner (small)</button>
+	<button class="demo-button" id="banner-product-compact">Product banner (compact)</button>
+</div>

--- a/demos/src/imperative.js
+++ b/demos/src/imperative.js
@@ -1,54 +1,189 @@
 
 import Banner from '../../main';
 
+const demoBannerConfigurations = [
+	{
+		elementId: 'banner-standard',
+		config: {
+			contentLong: `
+				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+			`,
+			contentShort: `
+				<p>Try the new compact homepage.</p>
+			`,
+			buttonLabel: 'Try it now',
+			linkLabel: 'Give feedback'
+		}
+	},
+	{
+		elementId: 'banner-small',
+		config: {
+			contentLong: `
+				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+			`,
+			contentShort: `
+				<p>Try the new compact homepage.</p>
+			`,
+			buttonLabel: 'Try it now',
+			linkLabel: 'Give feedback',
+			theme: ['small']
+		}
+	},
+	{
+		elementId: 'banner-compact',
+		config: {
+			contentLong: `
+				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+			`,
+			contentShort: `
+				<p>Try the new compact homepage.</p>
+			`,
+			buttonLabel: 'Try it now',
+			linkLabel: 'Give feedback',
+			theme: ['compact']
+		}
+	},
+	{
+		elementId: 'banner-marketing',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<p>Limited time only</p>
+					<h1>You qualify for a special offer: Save 33%</h1>
+				</header>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+				<ul>
+					<li>Global news and opinion from experts in 50+ countries</li>
+					<li>Access on desktop and mobile</li>
+					<li>Market-moving news, politics, tech, the arts and more</li>
+				</ul>
+			`,
+			contentShort: `
+				<h1>You qualify for a special offer: Save 33%</h1>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+			`,
+			buttonLabel: 'Save 33% now',
+			linkLabel: 'Terms and conditions',
+			theme: ['marketing']
+		}
+	},
+	{
+		elementId: 'banner-marketing-small',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<p>Limited time only</p>
+					<h1>You qualify for a special offer: Save 33%</h1>
+				</header>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+				<ul>
+					<li>Global news and opinion from experts in 50+ countries</li>
+					<li>Access on desktop and mobile</li>
+					<li>Market-moving news, politics, tech, the arts and more</li>
+				</ul>
+			`,
+			contentShort: `
+				<h1>You qualify for a special offer: Save 33%</h1>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+			`,
+			buttonLabel: 'Save 33% now',
+			linkLabel: 'Terms and conditions',
+			theme: ['small', 'marketing']
+		}
+	},
+	{
+		elementId: 'banner-marketing-compact',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<p>Limited time only</p>
+					<h1>You qualify for a special offer: Save 33%</h1>
+				</header>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+				<ul>
+					<li>Global news and opinion from experts in 50+ countries</li>
+					<li>Access on desktop and mobile</li>
+					<li>Market-moving news, politics, tech, the arts and more</li>
+				</ul>
+			`,
+			contentShort: `
+				<h1>You qualify for a special offer: Save 33%</h1>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+			`,
+			buttonLabel: 'Save 33% now',
+			linkLabel: 'Terms and conditions',
+			theme: ['compact', 'marketing']
+		}
+	},
+	{
+		elementId: 'banner-product',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<h1>FT Compact</h1>
+				</header>
+				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+			`,
+			contentShort: `
+				<header class="o-banner__heading">
+					<h1>FT Compact</h1>
+				</header>
+				<p>Try the new compact homepage.</p>
+			`,
+			buttonLabel: 'Try it now',
+			linkLabel: 'Give feedback',
+			theme: ['product']
+		}
+	},
+	{
+		elementId: 'banner-product-small',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<h1>FT Compact</h1>
+				</header>
+				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+			`,
+			contentShort: `
+				<header class="o-banner__heading">
+					<h1>FT Compact</h1>
+				</header>
+				<p>Try the new compact homepage.</p>
+			`,
+			buttonLabel: 'Try it now',
+			linkLabel: 'Give feedback',
+			theme: ['small', 'product']
+		}
+	},
+	{
+		elementId: 'banner-product-compact',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<h1>FT Compact</h1>
+				</header>
+				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+			`,
+			contentShort: `
+				<header class="o-banner__heading">
+					<h1>FT Compact</h1>
+				</header>
+				<p>Try the new compact homepage.</p>
+			`,
+			buttonLabel: 'Try it now',
+			linkLabel: 'Give feedback',
+			theme: ['compact', 'product']
+		}
+	}
+];
+
 function initDemos() {
 	document.addEventListener('DOMContentLoaded', () => {
-
-		document.getElementById('banner-standard').addEventListener('click', () => {
-			new Banner(null, {
-				contentLong: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
-				contentShort: 'Try the new compact homepage.',
-				buttonLabel: 'Try it now',
-				buttonUrl: '#try-button',
-				linkLabel: 'Give feedback',
-				linkUrl: '#feedback-link'
+		demoBannerConfigurations.forEach(({elementId, config}) => {
+			document.getElementById(elementId).addEventListener('click', () => {
+				new Banner(null, config);
 			});
 		});
-
-		document.getElementById('banner-small').addEventListener('click', () => {
-			new Banner(null, {
-				contentLong: 'Try the new compact homepage. A list view of today\'s homepage with fewer images.',
-				contentShort: 'Try the new compact homepage.',
-				buttonLabel: 'Try it now',
-				buttonUrl: '#try-button',
-				theme: 'small'
-			});
-		});
-
-		document.getElementById('banner-marketing').addEventListener('click', () => {
-			new Banner(null, {
-				contentLong: `
-					<header class="o-banner__heading">
-						<p>Limited time only</p>
-						<h1>You qualify for a special offer: Save 33%</h1>
-					</header>
-					<p>Pay just $4.29 per week for annual Standard Digital access.</p>
-					<ul>
-						<li>Global news and opinion from experts in 50+ countries</li>
-						<li>Access on desktop and mobile</li>
-						<li>Market-moving news, politics, tech, the arts and more</li>
-					</ul>
-				`,
-				contentShort: `
-					<h1>You qualify for a special offer: Save 33%</h1>
-					<p>Pay just $4.29 per week for annual Standard Digital access.</p>
-				`,
-				buttonLabel: 'Save 33% now',
-				buttonUrl: '#save-button',
-				theme: ['small', 'marketing']
-			});
-		});
-
 	});
 }
 

--- a/demos/src/imperative.mustache
+++ b/demos/src/imperative.mustache
@@ -1,6 +1,0 @@
-
-<div class="demo-buttons">
-	<button class="demo-button" id="banner-standard">Standard banner</button>
-	<button class="demo-button" id="banner-small">Small banner</button>
-	<button class="demo-button" id="banner-marketing">Marketing banner</button>
-</div>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -34,3 +34,21 @@
 		</div>
 	</div>
 </div>
+
+<div class="o-banner o-banner--product o-banner--static">
+	<div class="o-banner__outer">
+		<div class="o-banner__inner">
+			<div class="o-banner__content">
+				<p>Banner content.</p>
+			</div>
+			<div class="o-banner__actions">
+				<div class="o-banner__action">
+					<a href="#" class="o-banner__button">Button</a>
+				</div>
+				<div class="o-banner__action o-banner__action--secondary">
+					<a href="#" class="o-banner__link">Link</a>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/demos/src/product.mustache
+++ b/demos/src/product.mustache
@@ -1,5 +1,5 @@
 
-<div class="o-banner o-banner--small" data-o-component="o-banner">
+<div class="o-banner o-banner--small o-banner--product" data-o-component="o-banner">
 	<div class="o-banner__outer">
 		<div class="o-banner__inner" data-o-banner-inner="">
 			<div class="o-banner__content o-banner__content--long">

--- a/main.scss
+++ b/main.scss
@@ -12,6 +12,7 @@
 @import "src/scss/banner";
 
 @import "src/scss/themes/marketing";
+@import "src/scss/themes/product";
 @import "src/scss/themes/small";
 @import "src/scss/themes/compact";
 

--- a/origami.json
+++ b/origami.json
@@ -34,22 +34,29 @@
 			"description": "Small banner theme"
 		},
 		{
-			"title": "Marketing",
-			"name": "marketing",
-			"template": "demos/src/marketing.mustache",
-			"description": "Marketing banner theme"
-		},
-		{
 			"title": "Compact",
 			"name": "compact",
 			"template": "demos/src/compact.mustache",
 			"description": "Compact banner theme"
 		},
 		{
-			"title": "Imperative",
-			"name": "imperative",
-			"template": "demos/src/imperative.mustache",
-			"description": "Imperative banner",
+			"title": "Marketing",
+			"name": "marketing",
+			"template": "demos/src/marketing.mustache",
+			"description": "Marketing banner theme"
+		},
+		{
+			"title": "Product",
+			"name": "product",
+			"template": "demos/src/product.mustache",
+			"description": "Product banner theme"
+		},
+		{
+			"title": "All",
+			"name": "all",
+			"template": "demos/src/all.mustache",
+			"hidden": true,
+			"description": "All of the possible banner combinations",
 			"js": "demos/src/imperative.js"
 		},
 		{

--- a/src/scss/_banner.scss
+++ b/src/scss/_banner.scss
@@ -163,7 +163,7 @@
 		$baseColor: oColorsGetUseCase(o-banner-link, text),
 		$hoverColor: oColorsGetUseCase(o-banner-link, text),
 		$outlineColor: oColorsGetUseCase(o-banner-link, text),
-		$backgroundColor: 'teal'
+		$backgroundColor: oColorsGetUseCase(o-banner, background)
 	);
 	@include oTypographySans($scale: 0);
 	white-space: nowrap;

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,12 +1,12 @@
 
-@include oColorsSetUseCase(o-banner, background, 'teal');
-@include oColorsSetUseCase(o-banner, text, 'white');
-@include oColorsSetUseCase(o-banner-button, background, 'teal-60');
-@include oColorsSetUseCase(o-banner-button-active, text, 'teal-50');
-@include oColorsSetUseCase(o-banner-button, text, 'white');
-@include oColorsSetUseCase(o-banner-link, text, 'white');
-@include oColorsSetUseCase(o-banner-close, text, 'white');
-@include oColorsSetUseCase(o-banner-heading-rule, background, 'white');
+@include oColorsSetUseCase(o-banner, background, 'white');
+@include oColorsSetUseCase(o-banner, text, 'black');
+@include oColorsSetUseCase(o-banner-button, background, 'white');
+@include oColorsSetUseCase(o-banner-button, text, 'teal');
+@include oColorsSetUseCase(o-banner-button-active, text, 'white');
+@include oColorsSetUseCase(o-banner-link, text, 'teal');
+@include oColorsSetUseCase(o-banner-close, text, 'black');
+@include oColorsSetUseCase(o-banner-heading-rule, background, 'teal');
 
 @include oColorsSetUseCase(o-banner-marketing, background, 'white');
 @include oColorsSetUseCase(o-banner-marketing, text, 'black');
@@ -16,3 +16,12 @@
 @include oColorsSetUseCase(o-banner-marketing-link, text, 'black');
 @include oColorsSetUseCase(o-banner-marketing-close, text, 'black');
 @include oColorsSetUseCase(o-banner-marketing-heading-rule, background, 'teal-80');
+
+@include oColorsSetUseCase(o-banner-product, background, 'teal');
+@include oColorsSetUseCase(o-banner-product, text, 'white');
+@include oColorsSetUseCase(o-banner-product-button, background, 'teal-60');
+@include oColorsSetUseCase(o-banner-product-button-active, text, 'teal-50');
+@include oColorsSetUseCase(o-banner-product-button, text, 'white');
+@include oColorsSetUseCase(o-banner-product-link, text, 'white');
+@include oColorsSetUseCase(o-banner-product-close, text, 'white');
+@include oColorsSetUseCase(o-banner-product-heading-rule, background, 'white');

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -2,6 +2,8 @@
 @mixin _oBannerGetThemeMixin($theme, $class) {
 	@if $theme == 'marketing' {
 		@include oBannerThemeMarketing($class);
+	} @else if $theme == 'product' {
+		@include oBannerThemeProduct($class);
 	} @else if $theme == 'small' {
 		@include oBannerThemeSmall($class);
 	} @else if $theme == 'compact' {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,4 +3,4 @@ $o-banner-is-silent: true !default;
 
 $_o-banner-spacing: oTypographySpacingSize($units: 10) !default;
 $_o-banner-close-button-size: 26 !default;
-$_o-banner-themes: ('small', 'compact', 'marketing'); // order is important
+$_o-banner-themes: ('small', 'compact', 'marketing', 'product'); // order is important

--- a/src/scss/themes/_compact.scss
+++ b/src/scss/themes/_compact.scss
@@ -90,7 +90,7 @@
 	&:after {
 		@include oTypographyMargin($top: 2, $bottom: 3);
 		width: 60px;
-		border-bottom: oTypographySpacingSize(1) solid;
+		border-bottom-width: oTypographySpacingSize(1);
 	}
 }
 

--- a/src/scss/themes/_product.scss
+++ b/src/scss/themes/_product.scss
@@ -1,0 +1,88 @@
+
+@mixin oBannerThemeProductOuter() {
+	@include oColorsFor(o-banner-product, text background);
+}
+
+@mixin oBannerThemeProductSmallOuter() {
+	@include oColorsFor(o-banner-product, text);
+	background-color: transparent;
+}
+
+@mixin oBannerThemeProductSmallInner() {
+	@include oColorsFor(o-banner-product, background);
+}
+
+@mixin oBannerThemeProductContent() {
+	a {
+		@include oTypographyLinkCustom(
+			$baseColor: oColorsGetUseCase(o-banner-product-link, text),
+			$hoverColor: oColorsGetUseCase(o-banner-product-link, text),
+			$outlineColor: oColorsGetUseCase(o-banner-product-link, text),
+			$backgroundColor: oColorsGetUseCase(o-banner-product, background)
+		);
+	}
+}
+
+@mixin oBannerThemeProductHeading {
+	&:after {
+		border-color: oColorsGetColorFor(o-banner-product-heading-rule, background);
+	}
+}
+
+@mixin oBannerThemeProductButton {
+	@include oButtonsCustomTheme(oColorsGetUseCase(o-banner-product-button, background), oColorsGetUseCase(o-banner-product-button, text), primary);
+	// This is a hack around the fact that custom buttons do not
+	// support buttons with three colours. TODO: add this to o-buttons
+	// https://github.com/Financial-Times/o-buttons/issues/128
+	&,
+	&:not([disabled]):active {
+		@include oColorsFor(o-banner-product-button-active, text);
+	}
+}
+
+@mixin oBannerThemeProductLink {
+	@include oTypographyLinkCustom(
+		$baseColor: oColorsGetUseCase(o-banner-product-link, text),
+		$hoverColor: oColorsGetUseCase(o-banner-product-link, text),
+		$outlineColor: oColorsGetUseCase(o-banner-product-link, text),
+		$backgroundColor: oColorsGetUseCase(o-banner-product, background)
+	);
+}
+
+@mixin oBannerThemeProductCloseButton {
+	@include oIconsGetIcon('cross', oColorsGetColorFor(o-banner-product-close, text), $_o-banner-close-button-size, $iconset-version: 1);
+}
+
+@mixin oBannerThemeProduct($class: 'o-banner') {
+	.#{$class}--product {
+		.#{$class}__outer {
+			@include oBannerThemeProductOuter;
+		}
+		.#{$class}__content {
+			@include oBannerThemeProductContent;
+		}
+		.#{$class}__heading {
+			@include oBannerThemeProductHeading;
+		}
+		.#{$class}__button {
+			@include oBannerThemeProductButton;
+		}
+		.#{$class}__link {
+			@include oBannerThemeProductLink;
+		}
+		.#{$class}__close {
+			@include oBannerThemeProductCloseButton;
+		}
+
+		// When combined with the "small" and "compact" themes
+		&.#{$class}--small,
+		&.#{$class}--compact {
+			.#{$class}__outer {
+				@include oBannerThemeProductSmallOuter;
+			}
+			.#{$class}__inner {
+				@include oBannerThemeProductSmallInner;
+			}
+		}
+	}
+}


### PR DESCRIPTION
The existing teal default is now the "product" theme, and the new
default is white with teal buttons. There's also been some tidying up of
the demos - the imperative demo is now just for testing things locally
and features every possible banner combination.