### PR TITLE
Add a closeExistingBanners option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ There are several options used to change the appearance or behaviour of o-banner
 
   - `autoOpen`: Boolean. Whether to automatically open the banner. Defaults to `true`
   - `suppressCloseButton`: Boolean. Whether to hide the close button. Defaults to `false`
+  - `closeExistingBanners`: Boolean. Whether to automatically close all other banners when the new banner is instantiated. Defaults to `true`
   - `bannerClass`: String. The top-level banner class, which other classes will be based on. Defaults to `o-banner`
   - `contentLong`: String. The content to display on larger screens, or all screens if `contentShort` is not specified. Defaults to `&hellip;`
   - `contentShort`: String. The content to display on smaller screens. Defaults to the value of `contentLong`

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -17,6 +17,7 @@ class Banner {
 		this.options = Object.assign({}, {
 			autoOpen: true,
 			suppressCloseButton: false,
+			closeExistingBanners: true,
 
 			bannerClass: bannerClass,
 			bannerClosedClass: `${bannerClass}--closed`,
@@ -47,9 +48,13 @@ class Banner {
 		// Render the banner
 		this.render();
 
-		// There can be only one
-		Banner._bannerInstances.forEach(banner => banner.close());
-		Banner._bannerInstances = [this];
+		if (this.options.closeExistingBanners) {
+			// There can be only one
+			Banner._bannerInstances.forEach(banner => banner.close());
+			Banner._bannerInstances = [this];
+		} else {
+			Banner._bannerInstances.push(this);
+		}
 
 		if (this.options.autoOpen) {
 			this.open();

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -64,6 +64,7 @@ describe('Banner', () => {
 			assert.deepEqual(banner.options, {
 				autoOpen: true,
 				suppressCloseButton: false,
+				closeExistingBanners: true,
 				bannerClass: 'o-banner',
 				bannerClosedClass: 'o-banner--closed',
 				outerClass: 'o-banner__outer',


### PR DESCRIPTION
This allows people to disable the auto-closing behaviour. I've left it
in by default so that Build Service users get auto-closing banners and
reduce the number of breaking changes. This resolves #39