### PR TITLE
Allow for empty or partial banner content

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ Variable content based on screen size as well as the link after the button are o
 </div>
 ```
 
+If the banner element is empty, then the appropriate structure will be constructed with JavaScript using data attributes to specify [options](#options):
+
+```html
+<div
+    class="o-banner"
+    data-o-component="o-banner"
+    data-o-banner-content-long="Do you like o-banner?"
+    data-o-banner-button-label="Yes"
+></div>
+```
+
+If the banner element has content, but does _not_ include an `o-banner__outer` element, then it will assume that the element content should be wrapped in the appropriate markup:
+
+```html
+<div class="o-banner" data-o-component="o-banner">
+    <p>This is the banner content</p>
+</div>
+```
+
 ### JavaScript
 
 No code will run automatically unless you are using the Build Service. You must either construct an o-banner object or fire an `o.DOMContentLoaded` event, which o-banner listens for.

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -67,10 +67,21 @@ class Banner {
 	 * Render the banner.
 	 */
 	render () {
-		// If the banner element is not an HTML Element, build one
 		if (!(this.bannerElement instanceof HTMLElement)) {
+			// If the banner element is not an HTML Element, build one
 			this.bannerElement = this.buildBannerElement();
 			document.body.appendChild(this.bannerElement);
+
+		} else if (this.bannerElement.innerHTML.trim() === '') {
+			// If the banner element is empty, we construct the banner
+			this.bannerElement = this.buildBannerElement(this.bannerElement);
+
+		} else if (!this.bannerElement.querySelector(`.${this.options.outerClass}`)) {
+			// If the banner element is not empty and also does not contain an outer element,
+			// we assume the element content is the banner content
+			this.options.contentLong = this.bannerElement.innerHTML;
+			this.options.contentShort = null;
+			this.bannerElement = this.buildBannerElement(this.bannerElement);
 		}
 
 		// Select all the elements we need
@@ -100,11 +111,13 @@ class Banner {
 	}
 
 	/**
-	 * Build a full banner element. This is used when no banner exists in the DOM.
+	 * Build a full banner element. This is used when no banner or a partial banner exists in the DOM.
+	 * @param {HTMLElement} [bannerElement] - The banner element to build around
 	 * @returns {HTMLElement} Returns the new banner element
 	 */
-	buildBannerElement () {
-		const bannerElement = document.createElement('div');
+	buildBannerElement (bannerElement) {
+		bannerElement = bannerElement || document.createElement('div');
+		bannerElement.innerHTML = '';
 		bannerElement.classList.add(this.options.bannerClass);
 		let themes = [];
 		if (this.options.theme) {
@@ -113,7 +126,6 @@ class Banner {
 		themes.forEach(theme => {
 			bannerElement.classList.add(`${this.options.bannerClass}--${theme}`);
 		});
-		bannerElement.setAttribute('data-o-component', 'o-banner');
 		let contentHtml;
 		if (this.options.contentShort) {
 			contentHtml = `

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -228,7 +228,6 @@ describe('Banner', () => {
 			});
 
 			it('selects the inner element and stores it on the `innerElement` property', () => {
-				assert.calledOnce(bannerElement.querySelector);
 				assert.calledWithExactly(bannerElement.querySelector, '[data-o-banner-inner]');
 				assert.strictEqual(banner.innerElement, mockBannerInnerElement);
 			});
@@ -257,12 +256,68 @@ describe('Banner', () => {
 
 				it('builds a banner element and stores it on the `bannerElement` property', () => {
 					assert.calledOnce(banner.buildBannerElement);
+					assert.calledWithExactly(banner.buildBannerElement);
 					assert.strictEqual(banner.bannerElement, mockBannerElement);
 				});
 
 				it('appends the banner element to the body', () => {
 					assert.calledOnce(document.body.appendChild);
 					assert.calledWithExactly(document.body.appendChild, mockBannerElement);
+				});
+
+			});
+
+			describe('when the `bannerElement` property is an empty HTML element', () => {
+				let bannerElement;
+
+				beforeEach(() => {
+					bannerElement = banner.bannerElement = document.createElement('div');
+					sinon.stub(document.body, 'appendChild');
+					banner.render();
+				});
+
+				afterEach(() => {
+					document.body.appendChild.restore();
+				});
+
+				it('fully constructs the banner element and stores it on the `bannerElement` property', () => {
+					assert.calledOnce(banner.buildBannerElement);
+					assert.calledWith(banner.buildBannerElement, bannerElement);
+					assert.strictEqual(banner.bannerElement, mockBannerElement);
+				});
+
+				it('does not append the banner element to the body', () => {
+					assert.notCalled(document.body.appendChild);
+				});
+
+			});
+
+			describe('when the `bannerElement` property is an HTML element with content but no "outer" element', () => {
+				let bannerElement;
+
+				beforeEach(() => {
+					bannerElement = banner.bannerElement = document.createElement('div');
+					bannerElement.innerHTML = 'mock-content';
+					banner.options.contentLong = 'mock-content-long-old';
+					banner.options.contentShort = 'mock-content-short-old';
+					sinon.stub(document.body, 'appendChild');
+					banner.render();
+				});
+
+				afterEach(() => {
+					document.body.appendChild.restore();
+				});
+
+				it('fully constructs the banner element using the element HTML as content', () => {
+					assert.strictEqual(banner.options.contentLong, 'mock-content');
+					assert.strictEqual(banner.options.contentShort, null);
+					assert.calledOnce(banner.buildBannerElement);
+					assert.calledWith(banner.buildBannerElement, bannerElement);
+					assert.strictEqual(banner.bannerElement, mockBannerElement);
+				});
+
+				it('does not append the banner element to the body', () => {
+					assert.notCalled(document.body.appendChild);
 				});
 
 			});
@@ -370,7 +425,7 @@ describe('Banner', () => {
 
 			it('constructs the element HTML based on the given options', () => {
 				assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
-					<div class="mockBannerClass" data-o-component="o-banner">
+					<div class="mockBannerClass">
 						<div class="mockOuterClass">
 							<div class="mockInnerClass" data-o-banner-inner="">
 								<div class="mockContentClass mockContentLongClass">
@@ -402,7 +457,7 @@ describe('Banner', () => {
 
 				it('outputs only one content element using `options.contentLong`', () => {
 					assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
-						<div class="mockBannerClass" data-o-component="o-banner">
+						<div class="mockBannerClass">
 							<div class="mockOuterClass">
 								<div class="mockInnerClass" data-o-banner-inner="">
 									<div class="mockContentClass">
@@ -433,7 +488,7 @@ describe('Banner', () => {
 
 				it('does not include a secondary action/link', () => {
 					assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
-						<div class="mockBannerClass" data-o-component="o-banner">
+						<div class="mockBannerClass">
 							<div class="mockOuterClass">
 								<div class="mockInnerClass" data-o-banner-inner="">
 									<div class="mockContentClass mockContentLongClass">
@@ -464,7 +519,7 @@ describe('Banner', () => {
 
 				it('adds the theme class to the banner element', () => {
 					assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
-						<div class="mockBannerClass mockBannerClass--mock-theme" data-o-component="o-banner">
+						<div class="mockBannerClass mockBannerClass--mock-theme">
 							<div class="mockOuterClass">
 								<div class="mockInnerClass" data-o-banner-inner="">
 									<div class="mockContentClass mockContentLongClass">
@@ -501,7 +556,7 @@ describe('Banner', () => {
 
 				it('adds all of the theme classes to the banner element', () => {
 					assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
-						<div class="mockBannerClass mockBannerClass--mock-theme mockBannerClass--test-theme" data-o-component="o-banner">
+						<div class="mockBannerClass mockBannerClass--mock-theme mockBannerClass--test-theme">
 							<div class="mockOuterClass">
 								<div class="mockInnerClass" data-o-banner-inner="">
 									<div class="mockContentClass mockContentLongClass">
@@ -522,6 +577,25 @@ describe('Banner', () => {
 							</div>
 						</div>
 					`.replace(/[\t\n]+/g, ''));
+				});
+
+			});
+
+			describe('when `bannerElement` is passed in', () => {
+				let bannerElement;
+
+				beforeEach(() => {
+					bannerElement = document.createElement('div');
+					bannerElement.innerHTML = 'mock-original-content';
+					returnValue = banner.buildBannerElement();
+				});
+
+				it('strips the banner element HTML before constructing', () => {
+					assert.doesNotInclude(returnValue.outerHTML, 'mock-original-content');
+				});
+
+				it('returns the passed in banner element', () => {
+					assert.deepEqual(returnValue, bannerElement);
 				});
 
 			});


### PR DESCRIPTION
Now when you provide an empty banner element or a banner element with
only partial markup, we construct the rest of the markup around it.

With an empty element we construct the banner inside it, using data
attributes to configure it:

```html
<div
    class="o-banner"
    data-o-component="o-banner"
    data-o-banner-content-long="Do you like o-banner?"
    data-o-banner-button-label="Yes"
></div>
```

When the element has content but does not include an `o-banner__outer`
element, then we wrap the given content with the appropriate markup:

```html
<div class="o-banner" data-o-component="o-banner">
    <p>This is the banner content</p>
</div>
```

This stuff is needed to make cookie-message a little neater and easier
to understand, as we'll be constructing it from an empty element in a
lot of cases.