### PR TITLE
Update close button from link to an actual button.

### DIFF
--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -172,10 +172,8 @@ class Banner {
 	 * @returns {HTMLElement} Returns the new close button element
 	 */
 	buildCloseButtonElement () {
-		const closeButton = document.createElement('a');
+		const closeButton = document.createElement('button');
 		closeButton.className = this.options.closeButtonClass;
-		closeButton.setAttribute('role', 'button');
-		closeButton.setAttribute('href', '#void');
 		closeButton.setAttribute('aria-label', this.options.closeButtonLabel);
 		closeButton.setAttribute('title', this.options.closeButtonLabel);
 

--- a/src/scss/_banner.scss
+++ b/src/scss/_banner.scss
@@ -170,16 +170,22 @@
 }
 
 @mixin oBannerCloseButton {
-	$close-button-position: round(($_o-banner-spacing - $_o-banner-close-button-size) / 2);
 	@include oIconsGetIcon('cross', oColorsGetColorFor(o-banner-close, text), $_o-banner-close-button-size, $iconset-version: 1);
+	// start: undo button styles
+	appearance: none;
+	background: none;
+	color: inherit;
+	border: 0;
+	padding: 0;
+	font: inherit;
+	cursor: pointer;
+	outline: inherit;
+	// end: undo button styles
+	$close-button-position: round(($_o-banner-spacing - $_o-banner-close-button-size) / 2);
 	display: block;
 	position: absolute;
 	right: $close-button-position;
 	top: $close-button-position;
-
-	// Note: this is to combat the default link styles often
-	// provided by o-typography
-	border: 0;
 }
 
 @mixin oBanner($class: 'o-banner', $themes: 'all') {

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -630,7 +630,7 @@ describe('Banner', () => {
 
 			it('constructs the element HTML based on the given options', () => {
 				assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
-					<a class="mockCloseButtonClass" role="button" href="#void" aria-label="mockCloseButtonLabel" title="mockCloseButtonLabel"></a>
+					<button class="mockCloseButtonClass" aria-label="mockCloseButtonLabel" title="mockCloseButtonLabel"></button>
 				`.replace(/[\t\n]+/g, ''));
 			});
 


### PR DESCRIPTION
This was causing pa11y errors for Next. We did not get those errors as our pa11y demo does not include the close button, as we cannot include three banners in the same demo.