### PR TITLE
Allow the primary banner action to be a form

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ Variable content based on screen size as well as the link after the button are o
 </div>
 ```
 
+The banner's primary action can be a form with a submit button if required. Change the actions markup to the following:
+
+```html
+<div class="o-banner__actions">
+    <form class="o-banner__action" action="/example">
+        <input class="o-banner__button" type="submit" value="Try it now" />
+    </form>
+    …
+</div>
+```
+
 If the banner element is empty, then the appropriate structure will be constructed with JavaScript using data attributes to specify [options](#options):
 
 ```html
@@ -141,6 +152,9 @@ There are several options used to change the appearance or behaviour of o-banner
   - `contentShort`: String. The content to display on smaller screens. Defaults to the value of `contentLong`
   - `buttonLabel`: String. The banner button label. Defaults to `OK`
   - `buttonUrl`: String. The URL the button links to. Defaults to `#`
+  - `formAction`: String. A form action, if specified then the primary button will be a submit button in a form. Defaults to `null`
+  - `formEncoding`: String. The form encoding. Only used if `formAction` is not null. Defaults to `application/x-www-form-urlencoded`
+  - `formMethod`: String. The form method. Only used if `formAction` is not null. Defaults to `post`
   - `linkLabel`: String. The banner link label. Set to `null` to hide the link. Defaults to `null`
   - `linkUrl`: String. The URL the link links to. Defaults to `#`
   - `closeButtonLabel`: String. The hidden accessible label for the close button. Defaults to `Close`.

--- a/demos/src/all.mustache
+++ b/demos/src/all.mustache
@@ -16,3 +16,7 @@
 	<button class="demo-button" id="banner-product-small">Product banner (small)</button>
 	<button class="demo-button" id="banner-product-compact">Product banner (compact)</button>
 </div>
+
+<div class="demo-buttons">
+	<button class="demo-button" id="banner-form">Banner with a form</button>
+</div>

--- a/demos/src/form.mustache
+++ b/demos/src/form.mustache
@@ -1,0 +1,27 @@
+
+<div class="o-banner o-banner--small" data-o-component="o-banner">
+	<div class="o-banner__outer">
+		<div class="o-banner__inner" data-o-banner-inner="">
+			<div class="o-banner__content o-banner__content--long">
+				<header class="o-banner__heading">
+					<h1>FT Compact</h1>
+				</header>
+				<p>Try the new compact homepage. A list view of today's homepage with fewer images.</p>
+			</div>
+			<div class="o-banner__content o-banner__content--short">
+				<header class="o-banner__heading">
+					<h1>FT Compact</h1>
+				</header>
+				<p>Try the new compact homepage.</p>
+			</div>
+			<div class="o-banner__actions">
+				<form class="o-banner__action">
+					<input class="o-banner__button" type="submit" value="Try it now"/>
+				</form>
+				<div class="o-banner__action o-banner__action--secondary">
+					<a href="#" class="o-banner__link">Give feedback</a>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/demos/src/imperative.js
+++ b/demos/src/imperative.js
@@ -178,6 +178,33 @@ const demoBannerConfigurations = [
 			layout: 'compact',
 			theme: 'product'
 		}
+	},
+	{
+		elementId: 'banner-form',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<p>Limited time only</p>
+					<h1>You qualify for a special offer: Save 33%</h1>
+				</header>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+				<ul>
+					<li>Global news and opinion from experts in 50+ countries</li>
+					<li>Access on desktop and mobile</li>
+					<li>Market-moving news, politics, tech, the arts and more</li>
+				</ul>
+			`,
+			contentShort: `
+				<h1>You qualify for a special offer: Save 33%</h1>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+			`,
+			buttonLabel: 'Save 33% now',
+			linkLabel: 'Terms and conditions',
+			layout: 'small',
+			theme: 'marketing',
+			formAction: '#form-submitted',
+			formMethod: 'get'
+		}
 	}
 ];
 

--- a/origami.json
+++ b/origami.json
@@ -63,6 +63,13 @@
 			"js": "demos/src/imperative.js"
 		},
 		{
+			"title": "Form",
+			"name": "form",
+			"template": "demos/src/form.mustache",
+			"hidden": true,
+			"description": "Testing that a form and submit button can be used"
+		},
+		{
 			"title": "Pa11y",
 			"name": "pa11y",
 			"template": "demos/src/pa11y.mustache",

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -37,6 +37,9 @@ class Banner {
 			contentShort: null,
 			buttonLabel: 'OK',
 			buttonUrl: '#',
+			formAction: null,
+			formEncoding: 'application/x-www-form-urlencoded',
+			formMethod: 'post',
 			linkLabel: null,
 			linkUrl: '#',
 			closeButtonLabel: 'Close',
@@ -169,6 +172,20 @@ class Banner {
 				</div>
 			`;
 		}
+		let primaryActionHtml = '';
+		if (this.options.formAction !== null) {
+			primaryActionHtml = `
+				<form class="${classNames.action}" action="${this.options.formAction}" enctype="${this.options.formEncoding}" method="${this.options.formMethod}">
+					<input class="${classNames.button}" type="submit" value="${this.options.buttonLabel}"/>
+				</form>
+			`;
+		} else {
+			primaryActionHtml = `
+				<div class="${classNames.action}">
+					<a href="${this.options.buttonUrl}" class="${classNames.button}">${this.options.buttonLabel}</a>
+				</div>
+			`;
+		}
 		let secondaryActionHtml = '';
 		if (this.options.linkLabel) {
 			secondaryActionHtml = `
@@ -182,9 +199,7 @@ class Banner {
 				<div class="${classNames.inner}" data-o-banner-inner="">
 					${contentHtml}
 					<div class="${classNames.actions}">
-						<div class="${classNames.action}">
-							<a href="${this.options.buttonUrl}" class="${classNames.button}">${this.options.buttonLabel}</a>
-						</div>
+						${primaryActionHtml}
 						${secondaryActionHtml}
 					</div>
 				</div>

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -68,6 +68,9 @@ describe('Banner', () => {
 				contentShort: null,
 				buttonLabel: 'OK',
 				buttonUrl: '#',
+				formAction: null,
+				formEncoding: 'application/x-www-form-urlencoded',
+				formMethod: 'post',
 				linkLabel: null,
 				linkUrl: '#',
 				closeButtonLabel: 'Close',
@@ -622,6 +625,42 @@ describe('Banner', () => {
 
 				it('returns the passed in banner element', () => {
 					assert.deepEqual(returnValue, bannerElement);
+				});
+
+			});
+
+			describe('when `options.formAction` is not null', () => {
+
+				beforeEach(() => {
+					banner.options.formAction = 'mock-form-action';
+					banner.options.formEncoding = 'mock-form-encoding';
+					banner.options.formMethod = 'mock-form-method';
+					returnValue = banner.buildBannerElement();
+				});
+
+				it('uses a form and submit button in place of an anchor for the primary action', () => {
+					assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
+						<div class="o-banner">
+							<div class="o-banner__outer">
+								<div class="o-banner__inner" data-o-banner-inner="">
+									<div class="o-banner__content o-banner__content--long">
+										mockContentLong
+									</div>
+									<div class="o-banner__content o-banner__content--short">
+										mockContentShort
+									</div>
+									<div class="o-banner__actions">
+										<form class="o-banner__action" action="mock-form-action" enctype="mock-form-encoding" method="mock-form-method">
+											<input class="o-banner__button" type="submit" value="mockButtonLabel">
+										</form>
+										<div class="o-banner__action o-banner__action--secondary">
+											<a href="mockLinkUrl" class="o-banner__link">mockLinkLabel</a>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					`.replace(/[\t\n]+/g, ''));
 				});
 
 			});


### PR DESCRIPTION
The Envoy team need to use a form for a banner action. This allows you
to do so with both the declarative and imperative interfaces. This
resolves #92.