### PR TITLE
Banner Customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ There are several options used to change the appearance or behaviour of o-banner
 
 ## Sass
 
-As with all Origami components, o-tooltip has a [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles). To use its compiled CSS (rather than using its mixins with your own Sass) set `$o-banner-is-silent: false;` in your Sass before you've imported the o-banner Sass.
+As with all Origami components, o-banner has a [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles). To use its compiled CSS (rather than using its mixins with your own Sass) set `$o-banner-is-silent: false;` in your Sass before you've imported the o-banner Sass.
 
 o-banner includes a primary mixin that takes an `$opts` parameter. The `themes` key of `$opts` includes styles for [themes](#themes). The `layouts` key includes styles for [layouts](#layouts):
 
@@ -174,7 +174,7 @@ o-banner includes a primary mixin that takes an `$opts` parameter. The `themes` 
 ));
 ```
 
-If you call the mixin without arguments you will get all the themes:
+If you call the mixin without arguments you will get all the built-in themes:
 
 ```scss
 @include oBanner();
@@ -225,6 +225,60 @@ const myBanner = new oBanner({
     theme: 'marketing'
 });
 ```
+
+### Custom Themes
+
+The `oBannerAddTheme` mixin can be used to create and output styles for a custom banner theme. This allows you to alter colours and backgrounds completely:
+
+```scss
+@include oBannerAddTheme('bubblegum', (
+    background-color: oColorsMix('candy', 'white', 75),
+    text-color: oColorsByName('oxford-90')
+));
+```
+
+The above Sass will output CSS like this:
+
+```css
+.o-banner--bubblegum {
+    /* styles */
+}
+```
+
+You can add this new class to your banner element, either in the HTML:
+
+```html
+<div class="o-banner o-banner--bubblegum">
+    ...
+</div>
+```
+
+or via the `theme` option in JavaScript:
+
+```js
+const myBanner = new Banner(null, {
+    theme: 'bubblegum',
+    ...
+});
+```
+
+#### Custom Theme Options
+
+You can change a lot of aspects of a banner's visual appearance. When using the `oBannerAddTheme` mixin, you can specify the following properties:
+
+| Property                  | Required? | Type      | Description                                                                                                                                                                                |
+|---------------------------|-----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `background-color`        | Yes       | Colour*   | Sets the banner background colour                                                                                                                                                          |
+| `text-color`              | Yes       | Colour*   | Sets the banner's text colour                                                                                                                                                              |
+| `background-image`        | No        | String    | Sets the banner background image, this should be a URL. Defaults to no background                                                                                                          |
+| `background-position`     | No        | CSS value | Sets the banner background position, this can be any valid [`background-position` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position). Defaults to `bottom right` |
+| `background-repeat`       | No        | CSS Value | Sets the banner background repeat, this can be any valid [`background-repeat` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat). Defaults to `no-repeat`          |
+| `button-background-color` | No        | Colour*   | Sets the banner's primary action button colour. Defaults to the value of the `text-color` property                                                                                         |
+| `heading-rule-color`      | No        | Colour*   | Sets the banner's heading rule colour, the line that appears below the heading. Defaults to the value of the `text-color` property                                                         |
+| `link-text-color`         | No        | Colour*   | Sets the banner's link text colour, both in the banner content and the secondary action. Defaults to the value of the `text-color` property                                                |
+
+\* When a type of Colour is required, please specify a colour value and not an o-colors name. If you with to use an o-colors colour, then you can pass in `oColorsByName('<NAME>')`, replacing `<NAME>` with your desired color.
+
 
 ## Migration
 

--- a/demos/src/all.mustache
+++ b/demos/src/all.mustache
@@ -18,5 +18,11 @@
 </div>
 
 <div class="demo-buttons">
+	<button class="demo-button" id="banner-custom">Custom banner</button>
+	<button class="demo-button" id="banner-custom-small">Custom banner (small)</button>
+	<button class="demo-button" id="banner-custom-compact">Custom banner (compact)</button>
+</div>
+
+<div class="demo-buttons">
 	<button class="demo-button" id="banner-form">Banner with a form</button>
 </div>

--- a/demos/src/custom.mustache
+++ b/demos/src/custom.mustache
@@ -1,0 +1,34 @@
+
+<div class="o-banner o-banner--small o-banner--pikachu" data-o-component="o-banner">
+	<div class="o-banner__outer">
+		<div class="o-banner__inner" data-o-banner-inner="">
+			<div class="o-banner__content o-banner__content--long">
+				<header class="o-banner__heading">
+					<p>Limited time only</p>
+					<h1>You qualify for a special offer: Save 33%</h1>
+				</header>
+				<p>Pay just $4.29 per week for annual Standard  Digital access.</p>
+				<ul>
+					<li>Global news and opinion from experts in 50+ countries</li>
+					<li>Access on desktop and mobile</li>
+					<li>Market-moving news, politics, tech, the arts and more</li>
+				</ul>
+			</div>
+			<div class="o-banner__content o-banner__content--short">
+				<header class="o-banner__heading">
+					<p>Limited time only</p>
+					<h1>You qualify for a special offer: Save 33%</h1>
+				</header>
+				<p>Pay just $4.29 per week for annual Standard  Digital access.</p>
+			</div>
+			<div class="o-banner__actions">
+				<div class="o-banner__action">
+					<a href="#" class="o-banner__button">Save 33% now</a>
+				</div>
+				<div class="o-banner__action o-banner__action--secondary">
+					<a href="#" class="o-banner__link">Give feedback</a>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -27,5 +27,6 @@ body {
 	'text-color': oColorsByName('black'),
 	'background-color': oColorsByName('lemon'),
 	'heading-rule-color': oColorsByName('crimson'),
-	'button-background-color': oColorsByName('crimson')
+	'button-background-color': oColorsByName('crimson'),
+	'background-image': 'https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fi.imgur.com%2FIZmzrN7g.jpg?source=pikachu&width=200&format=png'
 ));

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -22,3 +22,10 @@ body {
 .o-banner--static {
 	position: static !important; // sass-lint:disable-line no-important
 }
+
+@include oBannerAddTheme('pikachu', (
+	'text-color': oColorsByName('black'),
+	'background-color': oColorsByName('lemon'),
+	'heading-rule-color': oColorsByName('crimson'),
+	'button-background-color': oColorsByName('crimson')
+));

--- a/demos/src/imperative.js
+++ b/demos/src/imperative.js
@@ -180,6 +180,80 @@ const demoBannerConfigurations = [
 		}
 	},
 	{
+		elementId: 'banner-custom',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<p>Limited time only</p>
+					<h1>You qualify for a special offer: Save 33%</h1>
+				</header>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+				<ul>
+					<li>Global news and opinion from experts in 50+ countries</li>
+					<li>Access on desktop and mobile</li>
+					<li>Market-moving news, politics, tech, the arts and more</li>
+				</ul>
+			`,
+			contentShort: `
+				<h1>You qualify for a special offer: Save 33%</h1>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+			`,
+			buttonLabel: 'Save 33% now',
+			linkLabel: 'Terms and conditions',
+			theme: 'pikachu'
+		}
+	},
+	{
+		elementId: 'banner-custom-small',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<p>Limited time only</p>
+					<h1>You qualify for a special offer: Save 33%</h1>
+				</header>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+				<ul>
+					<li>Global news and opinion from experts in 50+ countries</li>
+					<li>Access on desktop and mobile</li>
+					<li>Market-moving news, politics, tech, the arts and more</li>
+				</ul>
+			`,
+			contentShort: `
+				<h1>You qualify for a special offer: Save 33%</h1>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+			`,
+			buttonLabel: 'Save 33% now',
+			linkLabel: 'Terms and conditions',
+			layout: 'small',
+			theme: 'pikachu'
+		}
+	},
+	{
+		elementId: 'banner-custom-compact',
+		config: {
+			contentLong: `
+				<header class="o-banner__heading">
+					<p>Limited time only</p>
+					<h1>You qualify for a special offer: Save 33%</h1>
+				</header>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+				<ul>
+					<li>Global news and opinion from experts in 50+ countries</li>
+					<li>Access on desktop and mobile</li>
+					<li>Market-moving news, politics, tech, the arts and more</li>
+				</ul>
+			`,
+			contentShort: `
+				<h1>You qualify for a special offer: Save 33%</h1>
+				<p>Pay just $4.29 per week for annual Standard Digital access.</p>
+			`,
+			buttonLabel: 'Save 33% now',
+			linkLabel: 'Terms and conditions',
+			layout: 'compact',
+			theme: 'pikachu'
+		}
+	},
+	{
 		elementId: 'banner-form',
 		config: {
 			contentLong: `

--- a/origami.json
+++ b/origami.json
@@ -70,6 +70,13 @@
 			"description": "Testing that a form and submit button can be used"
 		},
 		{
+			"title": "Custom",
+			"name": "custom",
+			"template": "demos/src/custom.mustache",
+			"hidden": true,
+			"description": "Testing that custom banners work"
+		},
+		{
 			"title": "Pa11y",
 			"name": "pa11y",
 			"template": "demos/src/pa11y.mustache",

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -48,10 +48,8 @@ class Banner {
 		}, options || Banner.getOptionsFromDom(bannerElement));
 
 		// Validate theme choice.
-		const validThemes = ['product', 'marketing'];
-		const theme = this.options.theme;
-		if (theme && !validThemes.includes(theme)) {
-			throw new Error(`"${theme}" is not a valid theme. Use one of ${validThemes}.`);
+		if (this.options.theme && typeof this.options.theme !== 'string') {
+			throw new Error(`"${this.options.theme}" must be a string.`);
 		}
 
 		// Validate layout choice.

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -13,23 +13,23 @@
 @if oBrandGetCurrentBrand() == 'master' {
 	@include oBrandDefine('o-banner', 'master', (
 		'variables': (
-			'background': oColorsByName('white'),
-			'text': oColorsByName('black'),
-			'heading-rule': oColorsByName('teal'),
-			'button-background': oColorsByName('teal'),
+			'background-color': oColorsByName('white'),
+			'text-color': oColorsByName('black'),
+			'heading-rule-color': oColorsByName('teal'),
+			'button-background-color': oColorsByName('teal'),
 			'marketing': (
-				'background': oColorsByName('white'),
-				'text': oColorsByName('black'),
-				'heading-rule': oColorsByName('teal-80'),
-				'link-text': oColorsByName('black'),
-				'button-background': oColorsByName('black')
+				'background-color': oColorsByName('white'),
+				'text-color': oColorsByName('black'),
+				'heading-rule-color': oColorsByName('teal-80'),
+				'link-text-color': oColorsByName('black'),
+				'button-background-color': oColorsByName('black')
 			),
 			'product': (
-				'background': oColorsByName('teal'),
-				'text': oColorsByName('white'),
-				'heading-rule': oColorsByName('white'),
-				'link-text': oColorsByName('white'),
-				'button-background': oColorsByName('white')
+				'background-color': oColorsByName('teal'),
+				'text-color': oColorsByName('white'),
+				'heading-rule-color': oColorsByName('white'),
+				'link-text-color': oColorsByName('white'),
+				'button-background-color': oColorsByName('white')
 			)
 		),
 		'supports-variants': (

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -14,26 +14,23 @@
 	@include oBrandDefine('o-banner', 'master', (
 		'variables': (
 			'background': oColorsByName('white'),
-			'background-color-name': 'white',
 			'text': oColorsByName('black'),
 			'heading-rule': oColorsByName('teal'),
-			'button-color-name': 'teal',
+			'button-background': oColorsByName('teal'),
 			'marketing': (
 				'background': oColorsByName('white'),
-				'background-color-name': 'white',
 				'text': oColorsByName('black'),
 				'heading-rule': oColorsByName('teal-80'),
-				'link-color-name': 'black',
-				'button-color-name': 'black',
+				'link-text': oColorsByName('black'),
+				'button-background': oColorsByName('black')
 			),
 			'product': (
 				'background': oColorsByName('teal'),
-				'background-color-name': 'teal',
 				'text': oColorsByName('white'),
 				'heading-rule': oColorsByName('white'),
-				'link-color-name': 'white',
-				'button-color-name': 'white',
-			),
+				'link-text': oColorsByName('white'),
+				'button-background': oColorsByName('white')
+			)
 		),
 		'supports-variants': (
 			'marketing',

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -211,3 +211,27 @@
 	right: $close-button-position;
 	top: $close-button-position;
 }
+
+/// Add a theme modifier for banners.
+///
+/// @param {String} $theme-name - The banner theme to output styles for. See README for available themes, or specify a custom one if providing $opts.
+/// @param {Map} $opts [null] - A brand configuration which can be used to create a custom banner theme. See README for more examples.
+/// @output The output includes the `.o-banner--THEME` modifier class definition, which includes all overrides.
+/// @example scss - Existing banner theme
+///   @include oBannerAddTheme('marketing');
+/// @example scss - Custom banner theme
+///   @include oBannerAddTheme('bubblegum', (
+///       background-color: oColorsMix('candy', 'white', 75),
+///       text-color: oColorsByName('oxford-90')
+///   ));
+/// @access public
+@mixin oBannerAddTheme($theme-name, $opts: null) {
+
+	// If we have a custom config, we use that instead of one of the
+	// preconfigured themes
+	$variant: if($opts, $opts, $theme-name);
+
+	.o-banner--#{$theme-name} {
+		@include _oBannerTheme($variant);
+	}
+}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -181,8 +181,8 @@
 		'size': 'big',
 		'type': 'primary',
 		'theme': (
-			'color': _oBannerGet('button-color-name'),
-			'context': _oBannerGet('background-color-name')
+			'color': _oBannerGet('button-background'),
+			'context': _oBannerGet('background')
 		)
 	));
 	white-space: nowrap;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -48,8 +48,8 @@
 
 @mixin _oBannerOuter {
 	@include oVisualEffectsShadowContent('high');
-	background: _oBannerGet('background');
-	color: _oBannerGet('text');
+	background: _oBannerGet('background-color');
+	color: _oBannerGet('text-color');
 }
 
 @mixin _oBannerInner {
@@ -146,7 +146,7 @@
 
 		// Color is set separately for easier overriding later
 		border-bottom: oSpacingByIncrement(2) solid;
-		border-color: _oBannerGet('heading-rule');
+		border-color: _oBannerGet('heading-rule-color');
 	}
 }
 
@@ -181,8 +181,8 @@
 		'size': 'big',
 		'type': 'primary',
 		'theme': (
-			'color': _oBannerGet('button-background'),
-			'context': _oBannerGet('background')
+			'color': _oBannerGet('button-background-color'),
+			'context': _oBannerGet('background-color')
 		)
 	));
 	white-space: nowrap;
@@ -195,7 +195,7 @@
 }
 
 @mixin _oBannerCloseButton {
-	@include oIconsContent('cross', _oBannerGet('text'), $size: $_o-banner-close-button-size);
+	@include oIconsContent('cross', _oBannerGet('text-color'), $size: $_o-banner-close-button-size);
 	// start: undo button styles
 	appearance: none;
 	color: inherit;

--- a/src/scss/layouts/_compact.scss
+++ b/src/scss/layouts/_compact.scss
@@ -29,7 +29,7 @@
 @mixin _oBannerCompactInner {
 	@include oVisualEffectsShadowContent('high');
 	@include oTypographySans($scale: 0);
-	background: _oBannerGet('background');
+	background: _oBannerGet('background-color');
 	display: block;
 	padding: $_o-banner-spacing;
 	padding-top: oSpacingByIncrement(7);

--- a/src/scss/layouts/_small.scss
+++ b/src/scss/layouts/_small.scss
@@ -29,7 +29,7 @@
 @mixin _oBannerSmallInner {
 	@include oVisualEffectsShadowContent('high');
 	@include oTypographySans($scale: 2);
-	background: _oBannerGet('background');
+	background: _oBannerGet('background-color');
 	display: block;
 	padding: $_o-banner-spacing;
 	padding-top: oSpacingByIncrement(7);

--- a/src/scss/themes/_theme.scss
+++ b/src/scss/themes/_theme.scss
@@ -1,8 +1,8 @@
 @mixin _oBannerTheme($theme, $include-layout-styles: true) {
 
-	// Get and default some of the theme properties. Link, button, and rule colors
-	// default to text color, because we know this at least should be set to have
-	// a high enough contrast against the background
+	// Get and default the colour-based theme properties. Link, button, and rule
+	// colors default to text color, because we know this at least should be set
+	// to have a high enough contrast against the background
 	$text-color: _oBannerGet('text-color', $from: $theme);
 	$background-color: _oBannerGet('background-color', $from: $theme);
 	$link-text-color: _oBannerGet('link-text-color', $from: $theme);
@@ -14,8 +14,27 @@
 	$heading-rule-color: _oBannerGet('heading-rule-color', $from: $theme);
 	$heading-rule-color: if($heading-rule-color, $heading-rule-color, $text-color);
 
+	// Get and default background image theme properties
+	$background-image: _oBannerGet('background-image', $from: $theme);
+
+	// Background position defaults to bottom-right, because this is where all
+	// existing customisations keep their image. It's also the most sensible in
+	// terms of not obstructing content.
+	$background-position: _oBannerGet('background-position', $from: $theme);
+	$background-position: if($background-position, $background-position, bottom right);
+
+	// Background repeat defaults to no-repeat, because this matches all of
+	// the existing customisations and will not accidentally obstruct content.
+	$background-repeat: _oBannerGet('background-repeat', $from: $theme);
+	$background-repeat: if($background-repeat, $background-repeat, no-repeat);
+
 	.o-banner__outer {
-		background: $background-color;
+		@if ($background-image) {
+			background-image: url($background-image);
+			background-position: $background-position;
+			background-repeat: $background-repeat;
+		}
+		background-color: $background-color;
 		color: $text-color;
 	}
 	.o-banner__content {
@@ -58,11 +77,19 @@
 		&.o-banner--small,
 		&.o-banner--compact {
 			.o-banner__outer {
-				color: $text-color;
+				@if ($background-image) {
+					background-image: none;
+				}
 				background-color: transparent;
+				color: $text-color;
 			}
 			.o-banner__inner {
-				background: $background-color;
+				@if ($background-image) {
+					background-image: url($background-image);
+					background-position: $background-position;
+					background-repeat: $background-repeat;
+				}
+				background-color: $background-color;
 			}
 		}
 	}

--- a/src/scss/themes/_theme.scss
+++ b/src/scss/themes/_theme.scss
@@ -6,9 +6,9 @@
 	.o-banner__content {
 		a {
 			@include oTypographyLink($theme: (
-				'base': _oBannerGet('link-color-name', $from: $theme),
-				'hover': _oBannerGet('link-color-name', $from: $theme),
-				'context': _oBannerGet('background-color-name', $from: $theme)
+				'base': _oBannerGet('link-text', $from: $theme),
+				'hover': _oBannerGet('link-text', $from: $theme),
+				'context': _oBannerGet('background', $from: $theme)
 			));
 		}
 	}
@@ -22,16 +22,16 @@
 			'size': 'big',
 			'type': 'primary',
 			'theme': (
-				'color': _oBannerGet('button-color-name', $from: $theme),
-				'context': _oBannerGet('background-color-name', $from: $theme)
+				'color': _oBannerGet('button-background', $from: $theme),
+				'context': _oBannerGet('background', $from: $theme)
 			)
 		));
 	}
 	.o-banner__link {
 			@include oTypographyLink($theme: (
-				'base': _oBannerGet('link-color-name', $from: $theme),
-				'hover': _oBannerGet('link-color-name', $from: $theme),
-				'context': _oBannerGet('background-color-name', $from: $theme)
+				'base': _oBannerGet('link-text', $from: $theme),
+				'hover': _oBannerGet('link-text', $from: $theme),
+				'context': _oBannerGet('background', $from: $theme)
 			));
 	}
 	.o-banner__close {

--- a/src/scss/themes/_theme.scss
+++ b/src/scss/themes/_theme.scss
@@ -1,20 +1,20 @@
 @mixin _oBannerTheme($theme, $include-layout-styles) {
 	.o-banner__outer {
-		background: _oBannerGet('background', $from: $theme);
-		color: _oBannerGet('text', $from: $theme);
+		background: _oBannerGet('background-color', $from: $theme);
+		color: _oBannerGet('text-color', $from: $theme);
 	}
 	.o-banner__content {
 		a {
 			@include oTypographyLink($theme: (
-				'base': _oBannerGet('link-text', $from: $theme),
-				'hover': _oBannerGet('link-text', $from: $theme),
-				'context': _oBannerGet('background', $from: $theme)
+				'base': _oBannerGet('link-text-color', $from: $theme),
+				'hover': _oBannerGet('link-text-color', $from: $theme),
+				'context': _oBannerGet('background-color', $from: $theme)
 			));
 		}
 	}
 	.o-banner__heading {
 		&:after {
-			border-color: _oBannerGet('heading-rule', $from: $theme);
+			border-color: _oBannerGet('heading-rule-color', $from: $theme);
 		}
 	}
 	.o-banner__button {
@@ -22,20 +22,20 @@
 			'size': 'big',
 			'type': 'primary',
 			'theme': (
-				'color': _oBannerGet('button-background', $from: $theme),
-				'context': _oBannerGet('background', $from: $theme)
+				'color': _oBannerGet('button-background-color', $from: $theme),
+				'context': _oBannerGet('background-color', $from: $theme)
 			)
 		));
 	}
 	.o-banner__link {
-			@include oTypographyLink($theme: (
-				'base': _oBannerGet('link-text', $from: $theme),
-				'hover': _oBannerGet('link-text', $from: $theme),
-				'context': _oBannerGet('background', $from: $theme)
-			));
+		@include oTypographyLink($theme: (
+			'base': _oBannerGet('link-text-color', $from: $theme),
+			'hover': _oBannerGet('link-text-color', $from: $theme),
+			'context': _oBannerGet('background-color', $from: $theme)
+		));
 	}
 	.o-banner__close {
-		@include oIconsContent('cross', _oBannerGet('text', $from: $theme), $size: $_o-banner-close-button-size);
+		@include oIconsContent('cross', _oBannerGet('text-color', $from: $theme), $size: $_o-banner-close-button-size);
 	}
 
 	// When combined with the "small" and "compact" themes
@@ -43,11 +43,11 @@
 		&.o-banner--small,
 		&.o-banner--compact {
 			.o-banner__outer {
-				color: _oBannerGet('text', $from: $theme);
+				color: _oBannerGet('text-color', $from: $theme);
 				background-color: transparent;
 			}
 			.o-banner__inner {
-				background: _oBannerGet('background', $from: $theme);
+				background: _oBannerGet('background-color', $from: $theme);
 			}
 		}
 	}

--- a/src/scss/themes/_theme.scss
+++ b/src/scss/themes/_theme.scss
@@ -1,20 +1,35 @@
-@mixin _oBannerTheme($theme, $include-layout-styles) {
+@mixin _oBannerTheme($theme, $include-layout-styles: true) {
+
+	// Get and default some of the theme properties. Link, button, and rule colors
+	// default to text color, because we know this at least should be set to have
+	// a high enough contrast against the background
+	$text-color: _oBannerGet('text-color', $from: $theme);
+	$background-color: _oBannerGet('background-color', $from: $theme);
+	$link-text-color: _oBannerGet('link-text-color', $from: $theme);
+	$link-text-color: if($link-text-color, $link-text-color, $text-color);
+	$button-background-color: _oBannerGet('button-background-color', $from: $theme);
+	$button-background-color: if($button-background-color, $button-background-color, $text-color);
+	$button-background-color: _oBannerGet('button-background-color', $from: $theme);
+	$button-background-color: if($button-background-color, $button-background-color, $text-color);
+	$heading-rule-color: _oBannerGet('heading-rule-color', $from: $theme);
+	$heading-rule-color: if($heading-rule-color, $heading-rule-color, $text-color);
+
 	.o-banner__outer {
-		background: _oBannerGet('background-color', $from: $theme);
-		color: _oBannerGet('text-color', $from: $theme);
+		background: $background-color;
+		color: $text-color;
 	}
 	.o-banner__content {
 		a {
 			@include oTypographyLink($theme: (
-				'base': _oBannerGet('link-text-color', $from: $theme),
-				'hover': _oBannerGet('link-text-color', $from: $theme),
-				'context': _oBannerGet('background-color', $from: $theme)
+				'base': $link-text-color,
+				'hover': $link-text-color,
+				'context': $background-color
 			));
 		}
 	}
 	.o-banner__heading {
 		&:after {
-			border-color: _oBannerGet('heading-rule-color', $from: $theme);
+			border-color: $heading-rule-color;
 		}
 	}
 	.o-banner__button {
@@ -22,20 +37,20 @@
 			'size': 'big',
 			'type': 'primary',
 			'theme': (
-				'color': _oBannerGet('button-background-color', $from: $theme),
-				'context': _oBannerGet('background-color', $from: $theme)
+				'color': $button-background-color,
+				'context': $background-color
 			)
 		));
 	}
 	.o-banner__link {
 		@include oTypographyLink($theme: (
-			'base': _oBannerGet('link-text-color', $from: $theme),
-			'hover': _oBannerGet('link-text-color', $from: $theme),
-			'context': _oBannerGet('background-color', $from: $theme)
+			'base': $link-text-color,
+			'hover': $link-text-color,
+			'context': $background-color
 		));
 	}
 	.o-banner__close {
-		@include oIconsContent('cross', _oBannerGet('text-color', $from: $theme), $size: $_o-banner-close-button-size);
+		@include oIconsContent('cross', $text-color, $size: $_o-banner-close-button-size);
 	}
 
 	// When combined with the "small" and "compact" themes
@@ -43,11 +58,11 @@
 		&.o-banner--small,
 		&.o-banner--compact {
 			.o-banner__outer {
-				color: _oBannerGet('text-color', $from: $theme);
+				color: $text-color;
 				background-color: transparent;
 			}
 			.o-banner__inner {
-				background: _oBannerGet('background-color', $from: $theme);
+				background: $background-color;
 			}
 		}
 	}

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -556,16 +556,6 @@ describe('Banner', () => {
 				});
 			});
 
-			describe('when `options.theme` is an invalid theme', () => {
-				it('errors', () => {
-					assert.throws(() => {
-						banner = new Banner(null, {
-							theme: 'not-a-real-theme'
-						});
-					}, '');
-				});
-			});
-
 			describe('when `options.layout` is defined and is a string', () => {
 
 				beforeEach(() => {


### PR DESCRIPTION
This PR resolves #91, and should make it a lot easier for Envoy and the
Accounts team to create custom banners. I've added a new public mixin
named `oBannerAddTheme` which which works in the same way as custom
labels in [o-labels](https://github.com/Financial-Times/o-labels#mixin-olabelsaddstate).

---

Here's the section from the README, copied here to help understand how this works:

### Custom Themes

The `oBannerAddTheme` mixin can be used to create and output styles for a custom banner theme. This allows you to alter colours and backgrounds completely:

```scss
@include oBannerAddTheme('bubblegum', (
    background-color: oColorsMix('candy', 'white', 75),
    text-color: oColorsByName('oxford-90')
));
```

The above Sass will output CSS like this:

```css
.o-banner--bubblegum {
    /* styles */
}
```

You can add this new class to your banner element, either in the HTML:

```html
<div class="o-banner o-banner--bubblegum">
    ...
</div>
```

or via the `theme` option in JavaScript:

```js
const myBanner = new Banner(null, {
    theme: 'bubblegum',
    ...
});
```

#### Custom Theme Options

You can change a lot of aspects of a banner's visual appearance. When using the `oBannerAddTheme` mixin, you can specify the following properties:

| Property                  | Required? | Type      | Description                                                                                                                                                                                |
|---------------------------|-----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `background-color`        | Yes       | Colour*   | Sets the banner background colour                                                                                                                                                          |
| `text-color`              | Yes       | Colour*   | Sets the banner's text colour                                                                                                                                                              |
| `background-image`        | No        | String    | Sets the banner background image, this should be a URL. Defaults to no background                                                                                                          |
| `background-position`     | No        | CSS value | Sets the banner background position, this can be any valid [`background-position` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position). Defaults to `bottom right` |
| `background-repeat`       | No        | CSS Value | Sets the banner background repeat, this can be any valid [`background-repeat` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat). Defaults to `no-repeat`          |
| `button-background-color` | No        | Colour*   | Sets the banner's primary action button colour. Defaults to the value of the `text-color` property                                                                                         |
| `heading-rule-color`      | No        | Colour*   | Sets the banner's heading rule colour, the line that appears below the heading. Defaults to the value of the `text-color` property                                                         |
| `link-text-color`         | No        | Colour*   | Sets the banner's link text colour, both in the banner content and the secondary action. Defaults to the value of the `text-color` property                                                |

\* When a type of Colour is required, please specify a colour value and not an o-colors name. If you with to use an o-colors colour, then you can pass in `oColorsByName('<NAME>')`, replacing `<NAME>` with your desired color.
