### PR TITLE
Fix: show anchor when formAction is undefined

### DIFF
--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -173,7 +173,7 @@ class Banner {
 			`;
 		}
 		let primaryActionHtml = '';
-		if (this.options.formAction !== null) {
+		if (this.options.formAction !== null && this.options.formAction !== undefined) {
 			primaryActionHtml = `
 				<form class="${classNames.action}" action="${this.options.formAction}" enctype="${this.options.formEncoding}" method="${this.options.formMethod}">
 					<input class="${classNames.button}" type="submit" value="${this.options.buttonLabel}"/>

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -629,6 +629,66 @@ describe('Banner', () => {
 
 			});
 
+			describe('when `options.formAction` is not specified', () => {
+
+				it('uses an anchor in place of the form for the primary action when formAction is null', () => {
+					banner.options.formAction = null;
+					returnValue = banner.buildBannerElement();
+
+					assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
+						<div class="o-banner">
+							<div class="o-banner__outer">
+								<div class="o-banner__inner" data-o-banner-inner="">
+									<div class="o-banner__content o-banner__content--long">
+										mockContentLong
+									</div>
+									<div class="o-banner__content o-banner__content--short">
+										mockContentShort
+									</div>
+									<div class="o-banner__actions">
+										<div class="o-banner__action">
+											<a href="mockButtonUrl" class="o-banner__button">mockButtonLabel</a>
+										</div>
+										<div class="o-banner__action o-banner__action--secondary">
+											<a href="mockLinkUrl" class="o-banner__link">mockLinkLabel</a>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					`.replace(/[\t\n]+/g, ''));
+				});
+
+				it('uses an anchor in place of the form for the primary action when formAction is undefined', () => {
+					banner.options.formAction = undefined;
+					returnValue = banner.buildBannerElement();
+
+					assert.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
+						<div class="o-banner">
+							<div class="o-banner__outer">
+								<div class="o-banner__inner" data-o-banner-inner="">
+									<div class="o-banner__content o-banner__content--long">
+										mockContentLong
+									</div>
+									<div class="o-banner__content o-banner__content--short">
+										mockContentShort
+									</div>
+									<div class="o-banner__actions">
+										<div class="o-banner__action">
+											<a href="mockButtonUrl" class="o-banner__button">mockButtonLabel</a>
+										</div>
+										<div class="o-banner__action o-banner__action--secondary">
+											<a href="mockLinkUrl" class="o-banner__link">mockLinkLabel</a>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					`.replace(/[\t\n]+/g, ''));
+				});
+
+			});
+
 			describe('when `options.formAction` is not null', () => {
 
 				beforeEach(() => {


### PR DESCRIPTION
We've come across an issue where we were sending a `buttonUrl` but the banner was still being created with a form wrapped around it with an `undefined` action (thus breaking the functionality).

This fixes it so it checks for both a `null` and `undefined` value for the `formAction` option (since an action of `""` is falsey, yet still valid and sometimes intended).

I've also added some tests around this to future proof a little bit.

[Related Ticket](https://financialtimes.atlassian.net/browse/ACQ-47)