### PR TITLE
add secondary button to the theme generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ You can change a lot of aspects of a banner's visual appearance. When using the 
 | `background-position`     | No        | CSS value | Sets the banner background position, this can be any valid [`background-position` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position). Defaults to `bottom right` |
 | `background-repeat`       | No        | CSS Value | Sets the banner background repeat, this can be any valid [`background-repeat` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat). Defaults to `no-repeat`          |
 | `button-background-color` | No        | Colour*   | Sets the banner's primary action button colour. Defaults to the value of the `text-color` property                                                                                         |
+| `button-type`             | No        | String        | Sets the banner's button type, this can be either `primary` or `secondary`. Defaults to `primary`                                                                                      |
 | `heading-rule-color`      | No        | Colour*   | Sets the banner's heading rule colour, the line that appears below the heading. Defaults to the value of the `text-color` property                                                         |
 | `link-text-color`         | No        | Colour*   | Sets the banner's link text colour, both in the banner content and the secondary action. Defaults to the value of the `text-color` property                                                |
 

--- a/src/scss/themes/_theme.scss
+++ b/src/scss/themes/_theme.scss
@@ -11,6 +11,8 @@
 	$button-background-color: if($button-background-color, $button-background-color, $text-color);
 	$button-background-color: _oBannerGet('button-background-color', $from: $theme);
 	$button-background-color: if($button-background-color, $button-background-color, $text-color);
+	$button-type: _oBannerGet('button-type', $from: $theme);
+	$button-type: if($button-type, $button-type, 'primary');
 	$heading-rule-color: _oBannerGet('heading-rule-color', $from: $theme);
 	$heading-rule-color: if($heading-rule-color, $heading-rule-color, $text-color);
 
@@ -54,17 +56,7 @@
 	.o-banner__button {
 		@include oButtonsContent((
 			'size': 'big',
-			'type': 'primary',
-			'theme': (
-				'color': $button-background-color,
-				'context': $background-color
-			)
-		));
-	}
-	.o-banner__button--secondary {
-		@include oButtonsContent((
-			'size': 'big',
-			'type': 'secondary',
+			'type': $button-type,
 			'theme': (
 				'color': $button-background-color,
 				'context': $background-color

--- a/src/scss/themes/_theme.scss
+++ b/src/scss/themes/_theme.scss
@@ -61,6 +61,16 @@
 			)
 		));
 	}
+	.o-banner__button--secondary {
+		@include oButtonsContent((
+			'size': 'big',
+			'type': 'secondary',
+			'theme': (
+				'color': $button-background-color,
+				'context': $background-color
+			)
+		));
+	}
 	.o-banner__link {
 		@include oTypographyLink($theme: (
 			'base': $link-text-color,


### PR DESCRIPTION
We have a bottom slot message CTA (Click To Action) offering the user to subscribe to FT's daily digest. When the user has subscribed, this message changes to this:

![image](https://user-images.githubusercontent.com/733849/76212669-e5042e80-6200-11ea-9e0b-5b95dee992a0.png)

with a further CTA to browser newsletters. We'd like to change this CTA to become secondary, like this:

![image](https://user-images.githubusercontent.com/733849/76212618-cd2caa80-6200-11ea-9093-17b060ce49df.png)

We use the banner theme generator for the colours.

This PR allows us to add a `o-banner__button--secondary` class to the button to show the secondary version, using our custom theme (shades of green).