### PR TITLE
Allow no o-banner actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ If the banner element has content, but does _not_ include an `o-banner__outer` e
 </div>
 ```
 
+To customise the layout of banner actions, for example to bring actions below banner content on desktop, remove both actions (`o-banner__actions`) and include your own action within banner content (`o-banner__content`). This allows more control of banner styles whilst avoiding CSS overrides which may visually break with `o-banner` style changes. Removing default actions is not recommended for design consistency, but may be used to create experimental banners.
+
+```diff
+<div class="o-banner" data-o-component="o-banner">
+	<div class="o-banner__outer">
+		<div class="o-banner__inner" data-o-banner-inner="">
+			<div class="o-banner__content">
++				<div class="my-custom-banner-content">
+					<p>Try the new compact homepage. A list view of today's homepage with fewer images.	</p>
++					<a href="#" class="my-custom-action">Try it now</a>
++				</div>
+			</div>
+-			<div class="o-banner__actions">
+-				<div class="o-banner__action">
+-					<a href="#" class="o-banner__button">Try it now</a>
+-				</div>
+-			</div>
+		</div>
+	</div>
+</div>
+```
+
 ## JavaScript
 
 No code will run automatically unless you are using the Build Service. You must either construct an o-banner object or fire an `o.DOMContentLoaded` event, which o-banner listens for.
@@ -150,7 +172,7 @@ There are several options used to change the appearance or behaviour of o-banner
 - `closeExistingBanners`: Boolean. Whether to automatically close all other banners when the new banner is instantiated. Defaults to `true`
 - `contentLong`: String. The content to display on larger screens, or all screens if `contentShort` is not specified. Defaults to `&hellip;`
 - `contentShort`: String. The content to display on smaller screens. Defaults to the value of `contentLong`
-- `buttonLabel`: String. The banner button label. Defaults to `OK`
+- `buttonLabel`: String. The banner button label. Set to `null` to hide the button. Defaults to `OK`
 - `buttonUrl`: String. The URL the button links to. Defaults to `#`
 - `formAction`: String. A form action, if specified then the primary button will be a submit button in a form. Defaults to `null`
 - `formEncoding`: String. The form encoding. Only used if `formAction` is not null. Defaults to `application/x-www-form-urlencoded`

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,6 +1,7 @@
 
-$o-banner-is-silent: false;
 @import '../../main';
+
+@include oBanner();
 
 body {
 	@include oTypographySans();
@@ -19,7 +20,7 @@ body {
 	));
 }
 
-.o-banner--static {
+.demo-banner-static {
 	position: static !important; // stylelint-disable-line declaration-no-important
 }
 
@@ -27,6 +28,10 @@ body {
 	'text-color': oColorsByName('black'),
 	'background-color': oColorsByName('lemon'),
 	'heading-rule-color': oColorsByName('crimson'),
-	'button-background-color': oColorsByName('crimson'),
-	'background-image': 'https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fi.imgur.com%2FIZmzrN7g.jpg?source=pikachu&width=200&format=png'
+	'button-background-color': oColorsByName('crimson')
 ));
+
+.demo-custom-content {
+	@include oTypographySerif(1);
+	text-align: center;
+}

--- a/demos/src/disabled-actions.mustache
+++ b/demos/src/disabled-actions.mustache
@@ -1,0 +1,17 @@
+
+<div class="o-banner" data-o-component="o-banner">
+	<div class="o-banner__outer">
+		<div class="o-banner__inner" data-o-banner-inner="">
+			<div class="o-banner__content o-banner__content--long">
+                <div class="demo-custom-content">
+                    <p>Here's an informative banner with disabled actions and custom content style.<br><a href="#">take me to place</a></p>
+                </div>
+			</div>
+			<div class="o-banner__content o-banner__content--short">
+                <div class="demo-custom-content">
+                    <p>A custom banner with disabled actions.<br><a href="#">take me to place</a></p>
+                </div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,5 +1,5 @@
 
-<div class="o-banner o-banner--static">
+<div class="o-banner demo-banner-static">
 	<div class="o-banner__outer">
 		<div class="o-banner__inner">
 			<div class="o-banner__content">
@@ -17,7 +17,7 @@
 	</div>
 </div>
 
-<div class="o-banner o-banner--marketing o-banner--static">
+<div class="o-banner o-banner--marketing demo-banner-static">
 	<div class="o-banner__outer">
 		<div class="o-banner__inner">
 			<div class="o-banner__content">
@@ -35,7 +35,7 @@
 	</div>
 </div>
 
-<div class="o-banner o-banner--product o-banner--static">
+<div class="o-banner o-banner--product demo-banner-static">
 	<div class="o-banner__outer">
 		<div class="o-banner__inner">
 			<div class="o-banner__content">

--- a/origami.json
+++ b/origami.json
@@ -55,6 +55,20 @@
 			"description": "Product banner theme"
 		},
 		{
+			"title": "Custom Theme",
+			"name": "custom-theme",
+			"template": "demos/src/custom.mustache",
+			"display_html": false,
+			"description": "This demo shows a custom banner theme created using o-banner Sass. It's used to show customisation is possible, not that this style is recommended. Currently Build Service users are not able to create a custom theme. See the README for more details."
+		},
+		{
+			"title": "Custom Call To Action Layout",
+			"name": "custom-actions",
+			"template": "demos/src/disabled-actions.mustache",
+			"display_html": false,
+			"description": "Although not recommended for design consistency, banner actions may be disabled entirely to further customise the layout of a banner within the banner content. See the README for more details."
+		},
+		{
 			"title": "All",
 			"name": "all",
 			"template": "demos/src/all.mustache",
@@ -68,13 +82,6 @@
 			"template": "demos/src/form.mustache",
 			"hidden": true,
 			"description": "Testing that a form and submit button can be used"
-		},
-		{
-			"title": "Custom",
-			"name": "custom",
-			"template": "demos/src/custom.mustache",
-			"hidden": true,
-			"description": "Testing that custom banners work"
 		},
 		{
 			"title": "Pa11y",

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -171,18 +171,20 @@ class Banner {
 			`;
 		}
 		let primaryActionHtml = '';
-		if (this.options.formAction !== null && this.options.formAction !== undefined) {
-			primaryActionHtml = `
-				<form class="${classNames.action}" action="${this.options.formAction}" enctype="${this.options.formEncoding}" method="${this.options.formMethod}">
-					<input class="${classNames.button}" type="submit" value="${this.options.buttonLabel}"/>
-				</form>
-			`;
-		} else {
-			primaryActionHtml = `
-				<div class="${classNames.action}">
-					<a href="${this.options.buttonUrl}" class="${classNames.button}">${this.options.buttonLabel}</a>
-				</div>
-			`;
+		if (this.options.buttonLabel) {
+			if (this.options.formAction !== null && this.options.formAction !== undefined) {
+				primaryActionHtml = `
+					<form class="${classNames.action}" action="${this.options.formAction}" enctype="${this.options.formEncoding}" method="${this.options.formMethod}">
+						<input class="${classNames.button}" type="submit" value="${this.options.buttonLabel}"/>
+					</form>
+				`;
+			} else {
+				primaryActionHtml = `
+					<div class="${classNames.action}">
+						<a href="${this.options.buttonUrl}" class="${classNames.button}">${this.options.buttonLabel}</a>
+					</div>
+				`;
+			}
 		}
 		let secondaryActionHtml = '';
 		if (this.options.linkLabel) {
@@ -196,10 +198,11 @@ class Banner {
 			<div class="${classNames.outer}">
 				<div class="${classNames.inner}" data-o-banner-inner="">
 					${contentHtml}
-					<div class="${classNames.actions}">
+					${(primaryActionHtml || secondaryActionHtml) &&
+					`<div class="${classNames.actions}">
 						${primaryActionHtml}
 						${secondaryActionHtml}
-					</div>
+					</div>`}
 				</div>
 			</div>
 		`;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -73,6 +73,12 @@
 }
 
 @mixin _oBannerContent {
+	// flex grow so banner content takes the full width
+	// when there are no banner actions, e.g. if the user
+	// only wants a banner to be dismissed with a close button,
+	// or they want a custom call to action within banner
+	// content
+	flex-grow: 1;
 	padding: 0 $_o-banner-spacing;
 
 	h1,

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -513,6 +513,64 @@ describe('Banner', () => {
 
 			});
 
+			describe('when `options.buttonLabel` is not a string', () => {
+
+				beforeEach(() => {
+					banner.options.buttonLabel = null;
+					returnValue = banner.buildBannerElement();
+				});
+
+				it('does not include a primary action', () => {
+					proclaim.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
+						<div class="o-banner">
+							<div class="o-banner__outer">
+								<div class="o-banner__inner" data-o-banner-inner="">
+									<div class="o-banner__content o-banner__content--long">
+										mockContentLong
+									</div>
+									<div class="o-banner__content o-banner__content--short">
+										mockContentShort
+									</div>
+									<div class="o-banner__actions">
+										<div class="o-banner__action o-banner__action--secondary">
+											<a href="mockLinkUrl" class="o-banner__link">mockLinkLabel</a>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					`.replace(/[\t\n]+/g, ''));
+				});
+
+			});
+
+			describe('when `options.buttonLabel` and `options.linkLabel` are not a string', () => {
+
+				beforeEach(() => {
+					banner.options.buttonLabel = null;
+					banner.options.linkLabel = null;
+					returnValue = banner.buildBannerElement();
+				});
+
+				it('does not include the actions element', () => {
+					proclaim.strictEqual(returnValue.outerHTML.replace(/[\t\n]+/g, ''), `
+						<div class="o-banner">
+							<div class="o-banner__outer">
+								<div class="o-banner__inner" data-o-banner-inner="">
+									<div class="o-banner__content o-banner__content--long">
+										mockContentLong
+									</div>
+									<div class="o-banner__content o-banner__content--short">
+										mockContentShort
+									</div>
+								</div>
+							</div>
+						</div>
+					`.replace(/[\t\n]+/g, ''));
+				});
+
+			});
+
 			describe('when `options.theme` is defined and is a string', () => {
 
 				beforeEach(() => {


### PR DESCRIPTION
- Allow no banner actions. For a banner with only a dismiss button
or action within banner content.
- Document how a custom banner action may be used within banner
content.
- Show examples of banner customisation in the registry (with html
hidden as users can't copy the custom markup).

These changes help create a new experimental banner design for ft.com.
Slack conversation: https://financialtimes.slack.com/archives/C02FU5ARJ/p1591613112334100
Banner design: https://ftnext.invisionapp.com/share/R3WDMKGNQBG#/screens/412691535

<img width="986" alt="Screenshot 2020-06-09 at 10 25 40" src="https://user-images.githubusercontent.com/10405691/84130799-9eaaaf80-aa3b-11ea-9a63-bdd39056396b.png">
