### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/imperative.js
+++ b/demos/src/imperative.js
@@ -1,5 +1,5 @@
 
-import Banner from '../../main';
+import Banner from '../../main.js';
 
 const demoBannerConfigurations = [
 	{

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 
-import Banner from './src/js/banner';
+import Banner from './src/js/banner.js';
 
 function constructAll () {
 	Banner.init();

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import Banner from './../src/js/banner';
-import mainFixture from './fixture/main';
+import Banner from './../src/js/banner.js';
+import mainFixture from './fixture/main.js';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import Banner from './../main';
-import {default as BannerSrc} from './../src/js/banner';
+import Banner from './../main.js';
+import {default as BannerSrc} from './../src/js/banner.js';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing